### PR TITLE
Add nightly release workflow and update build/release workflows

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -121,14 +121,14 @@ jobs:
           echo "🚀 Building Windows CLI executable..."
           cargo build --release --target x86_64-pc-windows-msvc -p leaf-cli
 
-          if [ ! -f "./target/x86_64-pc-windows-msvc/release/goose.exe" ]; then
+          if [ ! -f "./target/x86_64-pc-windows-msvc/release/leaf.exe" ]; then
             echo "❌ Windows CLI binary not found."
             ls -la ./target/x86_64-pc-windows-msvc/release/ || echo "Release directory doesn't exist"
             exit 1
           fi
 
           echo "✅ Windows CLI binary found!"
-          ls -la ./target/x86_64-pc-windows-msvc/release/goose.exe
+          ls -la ./target/x86_64-pc-windows-msvc/release/leaf.exe
 
       - name: Package CLI (Linux/macOS)
         if: matrix.use-cross
@@ -137,15 +137,15 @@ jobs:
           export TARGET="${{ matrix.architecture }}-${{ matrix.target-suffix }}"
 
           # Create a directory for the package contents
-          mkdir -p "target/${TARGET}/release/goose-package"
+          mkdir -p "target/${TARGET}/release/leaf-package"
 
-          # Copy the goose binary
-          cp "target/${TARGET}/release/goose" "target/${TARGET}/release/goose-package/"
+          # Copy the leaf binary
+          cp "target/${TARGET}/release/leaf" "target/${TARGET}/release/leaf-package/"
 
           # Create the tar archive
           cd "target/${TARGET}/release"
-          tar -cjf "goose-${TARGET}.tar.bz2" -C goose-package .
-          echo "ARTIFACT=target/${TARGET}/release/goose-${TARGET}.tar.bz2" >> $GITHUB_ENV
+          tar -cjf "leaf-${TARGET}.tar.bz2" -C leaf-package .
+          echo "ARTIFACT=target/${TARGET}/release/leaf-${TARGET}.tar.bz2" >> $GITHUB_ENV
 
       - name: Package CLI (Windows)
         if: matrix.os == 'windows'
@@ -153,13 +153,13 @@ jobs:
         run: |
           export TARGET="${{ matrix.architecture }}-${{ matrix.target-suffix }}"
 
-          mkdir -p "target/${TARGET}/release/goose-package"
+          mkdir -p "target/${TARGET}/release/leaf-package"
 
-          cp "target/${TARGET}/release/goose.exe" "target/${TARGET}/release/goose-package/"
+          cp "target/${TARGET}/release/leaf.exe" "target/${TARGET}/release/leaf-package/"
 
           cd "target/${TARGET}/release"
-          7z a -tzip "goose-${TARGET}.zip" goose-package/
-          echo "ARTIFACT=target/${TARGET}/release/goose-${TARGET}.zip" >> $GITHUB_ENV
+          7z a -tzip "leaf-${TARGET}.zip" leaf-package/
+          echo "ARTIFACT=target/${TARGET}/release/leaf-${TARGET}.zip" >> $GITHUB_ENV
 
       - name: Upload CLI artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,148 @@
+# Nightly release workflow for Leaf CLI
+# Builds and publishes nightly releases on schedule or manual trigger
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # Daily at 2 AM UTC
+  workflow_dispatch:  # Allow manual trigger
+    inputs:
+      ref:
+        description: 'Branch or commit to build (defaults to cli branch)'
+        required: false
+        default: 'cli'
+
+name: Nightly Release
+
+# Permissions needed for AWS OIDC authentication in called workflows
+permissions:
+  id-token: write   # Required for AWS OIDC authentication in called workflow
+  contents: write   # Required for creating releases and by actions/checkout
+  actions: read     # May be needed for some workflows
+  attestations: write  # Required for SLSA build provenance attestations
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ------------------------------------
+  # 1) Build CLI for multiple OS/Arch
+  # ------------------------------------
+  build-cli:
+    uses: ./.github/workflows/build-cli.yml
+    with:
+      ref: ${{ github.event.inputs.ref || 'cli' }}
+
+  # ------------------------------------
+  # 2) Upload Install CLI Script
+  # ------------------------------------
+  install-script:
+    name: Upload Install Script
+    runs-on: ubuntu-latest
+    needs: [build-cli]
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          ref: ${{ github.event.inputs.ref || 'cli' }}
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        with:
+          name: download_cli.sh
+          path: download_cli.sh
+
+  # ------------------------------------
+  # 3) Create/Update Nightly GitHub Release
+  # ------------------------------------
+  release:
+    name: Nightly Release
+    runs-on: ubuntu-latest
+    needs: [build-cli, install-script]
+    permissions:
+      contents: write
+      id-token: write      # Required for Sigstore OIDC signing
+      attestations: write  # Required for SLSA build provenance attestations
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        with:
+          merge-multiple: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f  # v3.2.0
+        with:
+          subject-path: |
+            leaf-*.tar.bz2
+            leaf-*.zip
+            download_cli.sh
+
+      # Delete old nightly releases (keep only latest)
+      - name: Delete old nightly releases
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            const { data: releases } = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 10
+            });
+            
+            for (const release of releases) {
+              if (release.tag_name === 'nightly' && release.id !== context.payload.release?.id) {
+                console.log(`Deleting old nightly release ${release.id}`);
+                await github.rest.repos.deleteRelease({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  release_id: release.id
+                });
+              }
+            }
+
+      # Update nightly tag to current commit
+      - name: Update nightly tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -fa nightly -m "Nightly build"
+          git push origin nightly --force
+
+      # Create/update the nightly release
+      - name: Release nightly
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b  # v1.20.0
+        with:
+          tag: nightly
+          name: Nightly
+          body: |
+            ## Leaf CLI Nightly Build
+            
+            **Build Date:** ${{ github.event.repository.updated_at }}
+            **Commit:** ${{ github.sha }}
+            **Branch:** ${{ github.event.inputs.ref || 'cli' }}
+            
+            This is an automated nightly build of the Leaf CLI. These builds are
+            created daily from the latest code on the `cli` branch.
+            
+            ### Installation
+            
+            #### Linux/macOS
+            ```bash
+            curl -sSL https://github.com/LeafAI/Leaf/releases/download/nightly/download_cli.sh | bash
+            ```
+            
+            #### Windows
+            Download the appropriate `.zip` file for your architecture and extract it.
+            
+            ### Supported Platforms
+            - Linux (x86_64, aarch64)
+            - macOS (x86_64, aarch64/Apple Silicon)
+            - Windows (x86_64)
+            
+            ### Warning
+            Nightly builds are bleeding-edge and may contain bugs. For stable releases,
+            please use the [versioned releases](https://github.com/LeafAI/Leaf/releases).
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: |
+            leaf-*.tar.bz2
+            leaf-*.zip
+            download_cli.sh
+          allowUpdates: true
+          omitBody: false
+          omitPrereleaseDuringUpdate: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,12 +61,8 @@ jobs:
         uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f  # v3.2.0
         with:
           subject-path: |
-            goose-*.tar.bz2
-            goose-*.zip
-            Goose*.zip
-            *.deb
-            *.rpm
-            *.flatpak
+            leaf-*.tar.bz2
+            leaf-*.zip
             download_cli.sh
 
       # Create/update the versioned release
@@ -75,12 +71,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: |
-            goose-*.tar.bz2
-            goose-*.zip
-            Goose*.zip
-            *.deb
-            *.rpm
-            *.flatpak
+            leaf-*.tar.bz2
+            leaf-*.zip
             download_cli.sh
           allowUpdates: true
           omitBody: true
@@ -94,12 +86,8 @@ jobs:
           name: Stable
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: |
-            goose-*.tar.bz2
-            goose-*.zip
-            Goose*.zip
-            *.deb
-            *.rpm
-            *.flatpak
+            leaf-*.tar.bz2
+            leaf-*.zip
             download_cli.sh
           allowUpdates: true
           omitBody: true


### PR DESCRIPTION
Closes #3

## Summary

This PR implements the nightly release workflow and updates existing workflows to use "leaf" naming instead of "goose", making them compatible with the CLI-only Leaf fork.

## Changes

### 1. New: `.github/workflows/nightly-release.yml`
- **Schedule**: Runs daily at 2 AM UTC
- **Manual trigger**: Supports `workflow_dispatch` with optional ref input
- **Multi-platform builds**: Linux (x86_64, aarch64), macOS (x86_64, aarch64), Windows (x86_64)
- **Release management**: 
  - Creates/updates `nightly` tag
  - Creates/updates `nightly` release with detailed information
  - Deletes old nightly releases (keeps only latest)
  - Includes build provenance attestations

### 2. Updated: `.github/workflows/build-cli.yml`
- Changed binary name from `goose` to `leaf`
- Changed package directory from `goose-package` to `leaf-package`
- Changed artifact names from `goose-*` to `leaf-*`
- All platforms (Linux, macOS, Windows) updated consistently

### 3. Updated: `.github/workflows/release.yml`
- Changed artifact patterns from `goose-*` to `leaf-*`
- **Removed desktop artifacts** (CLI-only focus):
  - Removed `Goose*.zip` (macOS desktop app)
  - Removed `*.deb` (Debian package)
  - Removed `*.rpm` (RPM package)
  - Removed `*.flatpak` (Flatpak package)
- Updated both versioned and stable release steps
- Updated build provenance attestation paths

## Artifacts

The workflows now produce:
- `leaf-x86_64-unknown-linux-gnu.tar.bz2`
- `leaf-aarch64-unknown-linux-gnu.tar.bz2`
- `leaf-x86_64-apple-darwin.tar.bz2`
- `leaf-aarch64-apple-darwin.tar.bz2`
- `leaf-x86_64-pc-windows-msvc.zip`
- `download_cli.sh`

## Testing

- [x] Workflow syntax validated
- [x] No references to "goose" or "Goose" remain in workflow files
- [x] All artifact patterns updated consistently

## Migration Notes

After merging:
1. The nightly workflow will run automatically on the next scheduled run (2 AM UTC)
2. Manual trigger available via GitHub Actions UI
3. Nightly releases will appear at: https://github.com/LeafAI/Leaf/releases/tag/nightly
4. Versioned releases will use new `leaf-*` naming