### PR TITLE
feat: Add inline shell command support

### DIFF
--- a/crates/leaf-cli/src/session/completion.rs
+++ b/crates/leaf-cli/src/session/completion.rs
@@ -412,7 +412,10 @@ impl Hinter for GooseCompleter {
             }
             HintStatus::Default => {
                 let newline_key = super::input::get_newline_key().to_ascii_uppercase();
-                Some(format!("Enter to send · Ctrl+{} newline", newline_key))
+                Some(format!(
+                    "Enter to send · Ctrl+{} new line · ! Shell",
+                    newline_key
+                ))
             }
         }
     }

--- a/crates/leaf-cli/src/session/input.rs
+++ b/crates/leaf-cli/src/session/input.rs
@@ -26,6 +26,7 @@ pub enum InputResult {
     Recipe(Option<String>),
     Compact,
     ToggleFullToolOutput,
+    Shell(String),
 }
 
 #[derive(Debug)]
@@ -144,6 +145,16 @@ pub fn get_input(
     // Handle non-slash commands first
     if !input.starts_with('/') {
         let trimmed = input.trim();
+
+        // Handle shell commands (prefix with !)
+        if trimmed.starts_with('!') {
+            let cmd = trimmed.strip_prefix('!').unwrap_or("").trim();
+            if cmd.is_empty() {
+                return Ok(InputResult::Retry);
+            }
+            return Ok(InputResult::Shell(cmd.to_string()));
+        }
+
         if trimmed.is_empty()
             || trimmed.eq_ignore_ascii_case("exit")
             || trimmed.eq_ignore_ascii_case("quit")
@@ -205,6 +216,16 @@ fn get_regular_input(
     // Handle non-slash commands first
     if !input.starts_with('/') {
         let trimmed = input.trim();
+
+        // Handle shell commands (prefix with !)
+        if trimmed.starts_with('!') {
+            let cmd = trimmed.strip_prefix('!').unwrap_or("").trim();
+            if cmd.is_empty() {
+                return Ok(InputResult::Retry);
+            }
+            return Ok(InputResult::Shell(cmd.to_string()));
+        }
+
         if trimmed.is_empty()
             || trimmed.eq_ignore_ascii_case("exit")
             || trimmed.eq_ignore_ascii_case("quit")
@@ -428,6 +449,9 @@ fn print_help() {
 /compact - Compact the current conversation to reduce context length while preserving key information.
 /? or /help - Display this help message
 /clear - Clears the current chat history
+
+Inline Shell:
+!command - Execute a shell command (e.g., !pwd, !git status)
 
 Navigation:
 Ctrl+C - Clear current line if text is entered, otherwise exit the session
@@ -686,5 +710,40 @@ mod tests {
         // Test recipe with invalid extension
         let result = handle_slash_command("/recipe /path/to/file.txt");
         assert!(matches!(result, Some(InputResult::Retry)));
+    }
+
+    #[test]
+    fn test_shell_command_parsing() {
+        // Test shell command parsing via get_input (we test the logic directly)
+        let test_cases: Vec<(&str, &str)> = vec![
+            ("!pwd", "pwd"),
+            ("!ls -la", "ls -la"),
+            ("!git status", "git status"),
+            ("!git status -s", "git status -s"),
+            ("! echo hello", "echo hello"),
+            ("!echo hello world", "echo hello world"),
+        ];
+
+        for (input, expected_cmd) in test_cases {
+            let trimmed = input.trim();
+            if trimmed.starts_with('!') {
+                let cmd = trimmed.strip_prefix('!').unwrap_or("").trim();
+                assert_eq!(cmd, expected_cmd);
+            }
+        }
+
+        // Test empty command after !
+        let empty = "!";
+        let trimmed = empty.trim();
+        assert!(trimmed.starts_with('!'));
+        let cmd = trimmed.strip_prefix('!').unwrap_or("").trim();
+        assert!(cmd.is_empty());
+
+        // Test just spaces after !
+        let spaces = "!   ";
+        let trimmed = spaces.trim();
+        assert!(trimmed.starts_with('!'));
+        let cmd = trimmed.strip_prefix('!').unwrap_or("").trim();
+        assert!(cmd.is_empty());
     }
 }

--- a/crates/leaf-cli/src/session/mod.rs
+++ b/crates/leaf-cli/src/session/mod.rs
@@ -603,6 +603,9 @@ impl CliSession {
                 history.save(editor);
                 self.handle_compact().await?;
             }
+            InputResult::Shell(cmd) => {
+                self.handle_shell_command(&cmd);
+            }
         }
         Ok(())
     }
@@ -806,6 +809,60 @@ impl CliSession {
                     "{}: {:?}",
                     console::style("Failed to generate recipe").red(),
                     e
+                );
+            }
+        }
+    }
+
+    fn handle_shell_command(&self, cmd: &str) {
+        use std::io::{BufRead, BufReader};
+        use std::process::{Command, Stdio};
+
+        let mut child = match Command::new("sh")
+            .arg("-c")
+            .arg(cmd)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(e) => {
+                eprintln!(
+                    "{}",
+                    console::style(format!("Failed to execute command: {}", e)).red()
+                );
+                return;
+            }
+        };
+
+        let stdout = child.stdout.take().map(BufReader::new);
+        let stderr = child.stderr.take().map(BufReader::new);
+
+        if let Some(reader) = stdout {
+            for line in reader.lines().map_while(Result::ok) {
+                println!("{}", line);
+            }
+        }
+
+        if let Some(reader) = stderr {
+            for line in reader.lines().map_while(Result::ok) {
+                eprintln!("{}", line);
+            }
+        }
+
+        match child.wait() {
+            Ok(status) => {
+                if !status.success() {
+                    eprintln!(
+                        "{}",
+                        console::style(format!("Command exited with status: {}", status)).red()
+                    );
+                }
+            }
+            Err(e) => {
+                eprintln!(
+                    "{}",
+                    console::style(format!("Failed to wait for command: {}", e)).red()
                 );
             }
         }


### PR DESCRIPTION
Closes #7

## Summary

Adds inline shell command support (prefixed with `!`) to execute shell commands directly from the prompt without leaving the CLI session.

## Changes

### crates/leaf-cli/src/session/input.rs
- Add `Shell(String)` variant to `InputResult` enum
- Add shell command detection logic in `get_input()` - checks for `!` prefix
- Add unit test `test_shell_command_parsing()` for the parsing logic

### crates/leaf-cli/src/session/mod.rs
- Add `handle_shell_command()` method that executes commands via `sh -c`
- Real-time output streaming using `BufReader`
- Handles stdout, stderr, and non-zero exit codes

### crates/leaf-cli/src/session/completion.rs
- Update hint bar with Shell hint

## Usage

```
🌿 !pwd           # Execute shell command
🌿 !git status -s # Execute with arguments
🌿 !              # Empty command - ignored
```

## Features
- Full shell syntax support (pipes, redirections, etc.)
- Real-time output streaming
- Commands not added to history
- Exit codes displayed on failure