### PR TITLE
feat: sync CLI from upstream block/goose (928f4ac46..59a96c986) (closes #14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,10 +367,13 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-util",
+ "openssl",
+ "openssl-sys",
  "pin-project-lite",
  "rustls",
  "rustls-pki-types",
  "tokio",
+ "tokio-openssl",
  "tokio-rustls",
  "tower-service",
 ]
@@ -2346,6 +2349,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3171,6 +3190,7 @@ dependencies = [
  "http",
  "leaf",
  "leaf-mcp",
+ "openssl",
  "rand 0.8.5",
  "rcgen",
  "reqwest 0.13.2",
@@ -3481,6 +3501,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
  "rand 0.8.5",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -4759,11 +4796,13 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4775,6 +4814,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -6427,6 +6467,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
+dependencies = [
+ "openssl",
+ "openssl-sys",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6455,10 +6516,12 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tungstenite",
 ]
@@ -6843,6 +6906,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.9.2",
  "rustls",
  "rustls-pki-types",

--- a/crates/leaf-server/Cargo.toml
+++ b/crates/leaf-server/Cargo.toml
@@ -11,7 +11,20 @@ description.workspace = true
 workspace = true
 
 [features]
-default = []
+default = ["rustls-tls"]
+rustls-tls = [
+    "reqwest/rustls",
+    "tokio-tungstenite/rustls-tls-native-roots",
+    "axum-server/tls-rustls",
+    "dep:rustls",
+    "dep:aws-lc-rs",
+]
+native-tls = [
+    "reqwest/native-tls",
+    "tokio-tungstenite/native-tls",
+    "axum-server/tls-openssl",
+    "dep:openssl",
+]
 telemetry = ["leaf/telemetry"]
 
 [dependencies]
@@ -38,21 +51,22 @@ thiserror = { workspace = true }
 clap = { workspace = true }
 serde_yaml = { workspace = true }
 utoipa = { workspace = true, features = ["axum_extras", "chrono"] }
-reqwest = { workspace = true, features = ["json", "rustls", "blocking", "multipart", "system-proxy"], default-features = false }
+reqwest = { workspace = true, features = ["json", "blocking", "multipart", "system-proxy"], default-features = false }
 tokio-util = { workspace = true }
 serde_path_to_error = "0.1.20"
-tokio-tungstenite = { version = "0.28.0", features = ["rustls-tls-native-roots"] }
+tokio-tungstenite = { version = "0.28.0" }
 url = { workspace = true }
 rand = { workspace = true }
 hex = "0.4.3"
 subtle = "2.6"
 socket2 = "0.6.1"
 fs2 = { workspace = true }
-rustls = { version = "0.23", features = ["aws_lc_rs"] }
+rustls = { version = "0.23", features = ["aws_lc_rs"], optional = true }
 uuid = { workspace = true }
 rcgen = "0.13"
-axum-server = { version = "0.8.0", features = ["tls-rustls"] }
-aws-lc-rs = "1.16.0"
+axum-server = { version = "0.8.0" }
+aws-lc-rs = { version = "1.16.0", optional = true }
+openssl = { version = "0.10", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winreg = { version = "0.55.0" }

--- a/crates/leaf-server/src/commands/agent.rs
+++ b/crates/leaf-server/src/commands/agent.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use axum::middleware;
 use axum_server::Handle;
 use leaf_server::auth::check_token;
+#[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
 use leaf_server::tls::self_signed_config;
 use tower_http::cors::{Any, CorsLayer};
 use tracing::info;
@@ -31,13 +32,14 @@ pub async fn run() -> Result<()> {
     // gateways, etc.) try to open TLS connections. Both `ring` and `aws-lc-rs`
     // features are enabled on rustls (via different transitive deps), so rustls
     // cannot auto-detect a provider — we must pick one explicitly.
+    #[cfg(feature = "rustls-tls")]
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    crate::logging::setup_logging(Some("goosed"))?;
+    crate::logging::setup_logging(Some("leafd"))?;
 
     let settings = configuration::Settings::new()?;
 
-    let secret_key = std::env::var("GOOSE_SERVER__SECRET_KEY")
+    let secret_key = std::env::var("LEAF_SERVER__SECRET_KEY")
         .unwrap_or_else(|_| hex::encode(rand::random::<[u8; 32]>()));
 
     let app_state = state::AppState::new(settings.tls).await?;
@@ -74,21 +76,39 @@ pub async fn run() -> Result<()> {
     });
 
     if settings.tls {
-        let tls_setup = self_signed_config().await?;
+        #[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
+        {
+            let tls_setup = self_signed_config().await?;
 
-        let handle = Handle::new();
-        let shutdown_handle = handle.clone();
-        tokio::spawn(async move {
-            shutdown_signal().await;
-            shutdown_handle.graceful_shutdown(None);
-        });
+            let handle = Handle::new();
+            let shutdown_handle = handle.clone();
+            tokio::spawn(async move {
+                shutdown_signal().await;
+                shutdown_handle.graceful_shutdown(None);
+            });
 
-        info!("listening on https://{}", addr);
+            info!("listening on https://{}", addr);
 
-        axum_server::bind_rustls(addr, tls_setup.config)
-            .handle(handle)
-            .serve(app.into_make_service())
-            .await?;
+            #[cfg(feature = "rustls-tls")]
+            axum_server::bind_rustls(addr, tls_setup.config)
+                .handle(handle)
+                .serve(app.into_make_service())
+                .await?;
+
+            #[cfg(feature = "native-tls")]
+            axum_server::bind_openssl(addr, tls_setup.config)
+                .handle(handle)
+                .serve(app.into_make_service())
+                .await?;
+        }
+
+        #[cfg(not(any(feature = "rustls-tls", feature = "native-tls")))]
+        {
+            anyhow::bail!(
+                "TLS was requested but no TLS backend is enabled. \
+                 Enable the `rustls-tls` or `native-tls` feature."
+            );
+        }
     } else {
         let listener = tokio::net::TcpListener::bind(addr).await?;
 

--- a/crates/leaf-server/src/lib.rs
+++ b/crates/leaf-server/src/lib.rs
@@ -1,3 +1,9 @@
+#[cfg(not(any(feature = "rustls-tls", feature = "native-tls")))]
+compile_error!("At least one of `rustls-tls` or `native-tls` features must be enabled");
+
+#[cfg(all(feature = "rustls-tls", feature = "native-tls"))]
+compile_error!("Features `rustls-tls` and `native-tls` are mutually exclusive");
+
 pub mod auth;
 pub mod configuration;
 pub mod error;
@@ -5,6 +11,7 @@ pub mod openapi;
 pub mod routes;
 pub mod session_event_bus;
 pub mod state;
+#[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
 pub mod tls;
 pub mod tunnel;
 

--- a/crates/leaf-server/src/tls.rs
+++ b/crates/leaf-server/src/tls.rs
@@ -1,26 +1,35 @@
+//! TLS configuration for the leaf server.
+//!
+//! Two TLS backends are supported for the HTTPS listener via `axum-server`:
+//!
+//! - **`rustls-tls`** (enabled by default) – uses `axum-server/tls-rustls` with
+//!   the `aws-lc-rs` crypto provider.
+//! - **`native-tls`** – uses `axum-server/tls-openssl`, which links against the
+//!   platform's OpenSSL (or a compatible fork such as LibreSSL / BoringSSL).
+//!   On Linux this *is* the platform-native TLS stack; on macOS/Windows the
+//!   `native-tls` crate used by the HTTP *client* delegates to Security.framework
+//!   / SChannel respectively, but `axum-server` does not offer those backends so
+//!   the server listener always uses OpenSSL when this feature is active.
+
 use anyhow::Result;
-use aws_lc_rs::digest;
-use axum_server::tls_rustls::RustlsConfig;
 use rcgen::{CertificateParams, DnType, KeyPair, SanType};
 
+#[cfg(feature = "rustls-tls")]
+pub type TlsConfig = axum_server::tls_rustls::RustlsConfig;
+
+#[cfg(feature = "native-tls")]
+pub type TlsConfig = axum_server::tls_openssl::OpenSSLConfig;
+
 pub struct TlsSetup {
-    pub config: RustlsConfig,
+    pub config: TlsConfig,
     pub fingerprint: String,
 }
 
-/// Generate a self-signed TLS certificate for localhost (127.0.0.1) and
-/// return a [`TlsSetup`] containing the rustls config and the SHA-256
-/// fingerprint of the generated certificate (colon-separated hex).
-///
-/// The fingerprint is printed to stdout so the parent process (e.g. Electron)
-/// can pin it and reject connections from any other certificate.
-pub async fn self_signed_config() -> Result<TlsSetup> {
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
+fn generate_self_signed_cert() -> Result<(rcgen::Certificate, KeyPair)> {
     let mut params = CertificateParams::default();
     params
         .distinguished_name
-        .push(DnType::CommonName, "goosed localhost");
+        .push(DnType::CommonName, "leafd localhost");
     params.subject_alt_names = vec![
         SanType::IpAddress(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
         SanType::DnsName("localhost".try_into()?),
@@ -28,22 +37,62 @@ pub async fn self_signed_config() -> Result<TlsSetup> {
 
     let key_pair = KeyPair::generate()?;
     let cert = params.self_signed(&key_pair)?;
+    Ok((cert, key_pair))
+}
 
-    let cert_der = cert.der();
-    let sha256 = digest::digest(&digest::SHA256, cert_der);
-    let fingerprint = sha256
-        .as_ref()
-        .iter()
-        .map(|b| format!("{b:02X}"))
-        .collect::<Vec<_>>()
-        .join(":");
+fn sha256_fingerprint(der: &[u8]) -> String {
+    #[cfg(feature = "rustls-tls")]
+    {
+        let sha256 = aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, der);
+        sha256
+            .as_ref()
+            .iter()
+            .map(|b| format!("{b:02X}"))
+            .collect::<Vec<_>>()
+            .join(":")
+    }
 
-    println!("GOOSED_CERT_FINGERPRINT={fingerprint}");
+    #[cfg(feature = "native-tls")]
+    {
+        use openssl::hash::MessageDigest;
+        let digest =
+            openssl::hash::hash(MessageDigest::sha256(), der).expect("SHA-256 hash failed");
+        digest
+            .iter()
+            .map(|b| format!("{b:02X}"))
+            .collect::<Vec<_>>()
+            .join(":")
+    }
+}
+
+/// Generate a self-signed TLS certificate for localhost (127.0.0.1) and
+/// return a [`TlsSetup`] containing the server config and the SHA-256
+/// fingerprint of the generated certificate (colon-separated hex).
+///
+/// The fingerprint is printed to stdout so the parent process (e.g. Electron)
+/// can pin it and reject connections from any other certificate.
+pub async fn self_signed_config() -> Result<TlsSetup> {
+    #[cfg(feature = "rustls-tls")]
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    let (cert, key_pair) = generate_self_signed_cert()?;
+
+    let fingerprint = sha256_fingerprint(cert.der());
+    println!("LEAFD_CERT_FINGERPRINT={fingerprint}");
 
     let cert_pem = cert.pem();
     let key_pem = key_pair.serialize_pem();
 
-    let config = RustlsConfig::from_pem(cert_pem.into_bytes(), key_pem.into_bytes()).await?;
+    #[cfg(feature = "rustls-tls")]
+    let config = axum_server::tls_rustls::RustlsConfig::from_pem(
+        cert_pem.into_bytes(),
+        key_pem.into_bytes(),
+    )
+    .await?;
+
+    #[cfg(feature = "native-tls")]
+    let config =
+        axum_server::tls_openssl::OpenSSLConfig::from_pem(cert_pem.as_bytes(), key_pem.as_bytes())?;
 
     Ok(TlsSetup {
         config,

--- a/crates/leaf-server/src/tunnel/lapstone.rs
+++ b/crates/leaf-server/src/tunnel/lapstone.rs
@@ -485,6 +485,7 @@ async fn run_single_connection(
     scheme: String,
     restart_tx: mpsc::Sender<()>,
 ) {
+    #[cfg(feature = "rustls-tls")]
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
     let worker_url = get_worker_url();

--- a/crates/leaf/src/acp/provider.rs
+++ b/crates/leaf/src/acp/provider.rs
@@ -27,6 +27,7 @@ use crate::permission::permission_confirmation::PrincipalType;
 use crate::permission::{Permission, PermissionConfirmation};
 use crate::providers::base::{MessageStream, PermissionRouting, Provider};
 use crate::providers::errors::ProviderError;
+use crate::subprocess::configure_subprocess;
 
 pub struct AcpProviderConfig {
     pub command: PathBuf,
@@ -638,6 +639,7 @@ async fn spawn_acp_process(config: &AcpProviderConfig) -> Result<Child> {
         cmd.env(key, value);
     }
 
+    configure_subprocess(&mut cmd);
     cmd.spawn().context("failed to spawn ACP process")
 }
 

--- a/crates/leaf/src/config/declarative_providers.rs
+++ b/crates/leaf/src/config/declarative_providers.rs
@@ -61,6 +61,8 @@ pub struct DeclarativeProviderConfig {
     pub env_vars: Option<Vec<EnvVarConfig>>,
     #[serde(default)]
     pub dynamic_models: Option<bool>,
+    #[serde(default)]
+    pub skip_canonical_filtering: bool,
 }
 
 fn default_requires_auth() -> bool {
@@ -215,6 +217,7 @@ pub fn create_custom_provider(
         base_path: params.base_path,
         env_vars: None,
         dynamic_models: None,
+        skip_canonical_filtering: false,
     };
 
     let custom_providers_dir = custom_providers_dir();
@@ -280,6 +283,7 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
             base_path: params.base_path,
             env_vars: existing_config.env_vars,
             dynamic_models: existing_config.dynamic_models,
+            skip_canonical_filtering: existing_config.skip_canonical_filtering,
         };
 
         let file_path = custom_providers_dir().join(format!("{}.json", updated_config.name));

--- a/crates/leaf/src/model.rs
+++ b/crates/leaf/src/model.rs
@@ -111,6 +111,12 @@ impl ModelConfig {
     }
 
     pub fn with_canonical_limits(mut self, provider_name: &str) -> Self {
+        if let Some(pm) = find_predefined_model(&self.model_name) {
+            if self.context_limit.is_none() {
+                self.context_limit = pm.context_limit;
+            }
+        }
+
         if let Some(canonical) =
             crate::providers::canonical::maybe_get_canonical_model(provider_name, &self.model_name)
         {
@@ -122,13 +128,6 @@ impl ModelConfig {
             }
             if self.reasoning.is_none() {
                 self.reasoning = canonical.reasoning;
-            }
-        }
-
-        // Try filling remaining gaps from predefined models
-        if self.context_limit.is_none() {
-            if let Some(pm) = find_predefined_model(&self.model_name) {
-                self.context_limit = pm.context_limit;
             }
         }
 

--- a/crates/leaf/src/providers/base.rs
+++ b/crates/leaf/src/providers/base.rs
@@ -530,6 +530,10 @@ pub trait Provider: Send + Sync {
         RetryConfig::default()
     }
 
+    fn skip_canonical_filtering(&self) -> bool {
+        false
+    }
+
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         Ok(vec![])
     }
@@ -537,6 +541,10 @@ pub trait Provider: Send + Sync {
     /// Fetch models filtered by canonical registry and usability
     async fn fetch_recommended_models(&self) -> Result<Vec<String>, ProviderError> {
         let all_models = self.fetch_supported_models().await?;
+
+        if self.skip_canonical_filtering() {
+            return Ok(all_models);
+        }
 
         let registry = CanonicalModelRegistry::bundled().map_err(|e| {
             ProviderError::ExecutionError(format!("Failed to load canonical registry: {}", e))

--- a/crates/leaf/src/providers/base.rs
+++ b/crates/leaf/src/providers/base.rs
@@ -372,6 +372,8 @@ pub struct Usage {
     pub input_tokens: Option<i32>,
     pub output_tokens: Option<i32>,
     pub total_tokens: Option<i32>,
+    pub cache_read_input_tokens: Option<i32>,
+    pub cache_write_input_tokens: Option<i32>,
 }
 
 fn sum_optionals<T>(a: Option<T>, b: Option<T>) -> Option<T>
@@ -394,6 +396,13 @@ impl Add for Usage {
             sum_optionals(self.input_tokens, other.input_tokens),
             sum_optionals(self.output_tokens, other.output_tokens),
             sum_optionals(self.total_tokens, other.total_tokens),
+        )
+        .with_cache_tokens(
+            sum_optionals(self.cache_read_input_tokens, other.cache_read_input_tokens),
+            sum_optionals(
+                self.cache_write_input_tokens,
+                other.cache_write_input_tokens,
+            ),
         )
     }
 }
@@ -425,7 +434,19 @@ impl Usage {
             input_tokens,
             output_tokens,
             total_tokens: calculated_total,
+            cache_read_input_tokens: None,
+            cache_write_input_tokens: None,
         }
+    }
+
+    pub fn with_cache_tokens(
+        mut self,
+        cache_read_input_tokens: Option<i32>,
+        cache_write_input_tokens: Option<i32>,
+    ) -> Self {
+        self.cache_read_input_tokens = cache_read_input_tokens;
+        self.cache_write_input_tokens = cache_write_input_tokens;
+        self
     }
 }
 

--- a/crates/leaf/src/providers/cursor_agent.rs
+++ b/crates/leaf/src/providers/cursor_agent.rs
@@ -23,7 +23,7 @@ use rmcp::model::Tool;
 
 const CURSOR_AGENT_PROVIDER_NAME: &str = "cursor-agent";
 pub const CURSOR_AGENT_DEFAULT_MODEL: &str = "auto";
-pub const CURSOR_AGENT_KNOWN_MODELS: &[&str] = &["auto", "gpt-5", "opus-4.1", "sonnet-4"];
+pub const CURSOR_AGENT_KNOWN_MODELS: &[&str] = &["auto", "composer-2", "composer-2-fast"];
 
 pub const CURSOR_AGENT_DOC_URL: &str = "https://docs.cursor.com/en/cli/overview";
 
@@ -205,10 +205,7 @@ impl CursorAgentProvider {
             cmd.env("PATH", path);
         }
 
-        // Only pass model parameter if it's in the known models list
-        if CURSOR_AGENT_KNOWN_MODELS.contains(&self.model.model_name.as_str()) {
-            cmd.arg("--model").arg(&self.model.model_name);
-        }
+        cmd.arg("--model").arg(&self.model.model_name);
 
         cmd.arg("-p")
             .arg(&prompt)

--- a/crates/leaf/src/providers/formats/openai.rs
+++ b/crates/leaf/src/providers/formats/openai.rs
@@ -125,7 +125,7 @@ pub fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<
 
         let mut output = Vec::new();
         let mut content_array = Vec::new();
-        let mut text_array = Vec::new();
+        let mut has_non_text_content = false;
         let mut reasoning_text = String::new();
 
         for content in &message.content {
@@ -135,16 +135,17 @@ pub fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<
                         if message.role == Role::User {
                             if let Some(image_path) = detect_image_path(&text.text) {
                                 if let Ok(image) = load_image_file(image_path) {
+                                    has_non_text_content = true;
                                     content_array.push(json!({"type": "text", "text": text.text}));
                                     content_array.push(convert_image(&image, image_format));
                                 } else {
-                                    text_array.push(text.text.clone());
+                                    content_array.push(json!({"type": "text", "text": text.text}));
                                 }
                             } else {
-                                text_array.push(text.text.clone());
+                                content_array.push(json!({"type": "text", "text": text.text}));
                             }
                         } else {
-                            text_array.push(text.text.clone());
+                            content_array.push(json!({"type": "text", "text": text.text}));
                         }
                     }
                 }
@@ -258,6 +259,7 @@ pub fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<
                 MessageContent::ActionRequired(_) => {}
                 MessageContent::Image(image) => {
                     if message.role == Role::User {
+                        has_non_text_content = true;
                         content_array.push(convert_image(image, image_format));
                     } else {
                         content_array.push(json!({
@@ -303,9 +305,15 @@ pub fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<
         }
 
         if !content_array.is_empty() {
-            converted["content"] = json!(content_array);
-        } else if !text_array.is_empty() {
-            converted["content"] = json!(text_array.join("\n"));
+            if has_non_text_content {
+                converted["content"] = json!(content_array);
+            } else {
+                let texts: Vec<String> = content_array
+                    .iter()
+                    .filter_map(|v| v["text"].as_str().map(|s| s.to_string()))
+                    .collect();
+                converted["content"] = json!(texts.join("\n"));
+            }
         }
 
         // Some strict OpenAI-compatible providers require "content" to be present
@@ -1208,6 +1216,38 @@ mod tests {
         assert!(content.unwrap().contains(png_path_str));
 
         Ok(())
+    }
+
+    #[test]
+    fn test_format_messages_with_text_and_image_preserves_order() {
+        let msg_text_first = Message::user()
+            .with_text("Describe this image")
+            .with_image("aW1hZ2VkYXRh", "image/png");
+
+        let spec = format_messages(&[msg_text_first], &ImageFormat::OpenAi);
+        assert_eq!(spec.len(), 1);
+        assert_eq!(spec[0]["role"], "user");
+
+        let content = spec[0]["content"]
+            .as_array()
+            .expect("content should be an array");
+        assert_eq!(content.len(), 2, "expected text + image entries");
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "Describe this image");
+        assert_eq!(content[1]["type"], "image_url");
+
+        let msg_image_first = Message::user()
+            .with_image("aW1hZ2VkYXRh", "image/png")
+            .with_text("What do you see?");
+
+        let spec2 = format_messages(&[msg_image_first], &ImageFormat::OpenAi);
+        let content2 = spec2[0]["content"]
+            .as_array()
+            .expect("content should be an array");
+        assert_eq!(content2.len(), 2, "expected image + text entries");
+        assert_eq!(content2[0]["type"], "image_url");
+        assert_eq!(content2[1]["type"], "text");
+        assert_eq!(content2[1]["text"], "What do you see?");
     }
 
     #[test]

--- a/crates/leaf/src/providers/formats/openai.rs
+++ b/crates/leaf/src/providers/formats/openai.rs
@@ -489,6 +489,11 @@ pub fn response_to_message(response: &Value) -> anyhow::Result<Message> {
 }
 
 pub fn get_usage(usage: &Value) -> Usage {
+    let usage = usage
+        .get("usage")
+        .filter(|nested| nested.is_object())
+        .unwrap_or(usage);
+
     let input_tokens = usage
         .get("prompt_tokens")
         .and_then(|v| v.as_i64())
@@ -499,16 +504,27 @@ pub fn get_usage(usage: &Value) -> Usage {
         .and_then(|v| v.as_i64())
         .map(|v| v as i32);
 
+    let cache_read_input_tokens = usage
+        .get("cache_read_input_tokens")
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32);
+
+    let cache_write_input_tokens = usage
+        .get("cache_creation_input_tokens")
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32);
+
     let total_tokens = usage
         .get("total_tokens")
         .and_then(|v| v.as_i64())
         .map(|v| v as i32)
         .or_else(|| match (input_tokens, output_tokens) {
-            (Some(input), Some(output)) => Some(input + output),
+            (Some(input), Some(output)) => Some(input.saturating_add(output)),
             _ => None,
         });
 
     Usage::new(input_tokens, output_tokens, total_tokens)
+        .with_cache_tokens(cache_read_input_tokens, cache_write_input_tokens)
 }
 
 fn extract_usage_with_output_tokens(chunk: &StreamingChunk) -> Option<ProviderUsage> {

--- a/crates/leaf/src/providers/opencode.rs
+++ b/crates/leaf/src/providers/opencode.rs
@@ -224,6 +224,7 @@ fn register_providers_from_catalog(
                 base_path: None,
                 env_vars: None,
                 dynamic_models: None,
+                skip_canonical_filtering: false,
             };
 
             register_declarative_provider(registry, config, ProviderType::Preferred);

--- a/download_cli.sh
+++ b/download_cli.sh
@@ -2,37 +2,37 @@
 set -eu
 
 ##############################################################################
-# goose CLI Install Script
+# leaf CLI Install Script
 #
-# This script downloads the latest stable 'goose' CLI binary from GitHub releases
+# This script downloads the latest stable 'leaf' CLI binary from GitHub releases
 # and installs it to your system.
 #
 # Supported OS: macOS (darwin), Linux, Windows (MSYS2/Git Bash/WSL)
 # Supported Architectures: x86_64, arm64
 #
 # Usage:
-#   curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
+#   curl -fsSL https://github.com/LeafAI/Leaf/releases/download/stable/download_cli.sh | bash
 #
 # Environment variables:
-#   GOOSE_BIN_DIR  - Directory to which goose will be installed (default: $HOME/.local/bin)
-#   GOOSE_VERSION  - Optional: specific version to install (e.g., "v1.0.25"). Overrides CANARY. Can be in the format vX.Y.Z, vX.Y.Z-suffix, or X.Y.Z
-#   GOOSE_PROVIDER - Optional: provider for goose
-#   GOOSE_MODEL    - Optional: model for goose
+#   LEAF_BIN_DIR  - Directory to which leaf will be installed (default: $HOME/.local/bin)
+#   LEAF_VERSION  - Optional: specific version to install (e.g., "v1.0.25"). Overrides CANARY. Can be in the format vX.Y.Z, vX.Y.Z-suffix, or X.Y.Z
+#   LEAF_PROVIDER - Optional: provider for leaf
+#   LEAF_MODEL    - Optional: model for leaf
 #   CANARY         - Optional: if set to "true", downloads from canary release instead of stable
-#   CONFIGURE      - Optional: if set to "false", disables running goose configure interactively
+#   CONFIGURE      - Optional: if set to "false", disables running leaf configure interactively
 #   ** other provider specific environment variables (eg. DATABRICKS_HOST)
 ##############################################################################
 
 # --- 1) Check for dependencies ---
 # Check for curl
 if ! command -v curl >/dev/null 2>&1; then
-  echo "Error: 'curl' is required to download goose. Please install curl and try again."
+  echo "Error: 'curl' is required to download leaf. Please install curl and try again."
   exit 1
 fi
 
 # Check for tar or unzip (depending on OS)
 if ! command -v tar >/dev/null 2>&1 && ! command -v unzip >/dev/null 2>&1; then
-  echo "Error: Either 'tar' or 'unzip' is required to extract goose. Please install one and try again."
+  echo "Error: Either 'tar' or 'unzip' is required to extract leaf. Please install one and try again."
   exit 1
 fi
 
@@ -52,13 +52,13 @@ fi
 
 
 # --- 2) Variables ---
-REPO="block/goose"
-OUT_FILE="goose"
+REPO="LeafAI/Leaf"
+OUT_FILE="leaf"
 
 # Set default bin directory based on detected OS environment
 if [[ "${WINDIR:-}" ]] || [[ "${windir:-}" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
     # Native Windows environments - use Windows user profile path
-    DEFAULT_BIN_DIR="$USERPROFILE/goose"
+    DEFAULT_BIN_DIR="$USERPROFILE/leaf"
 elif [[ -f "/proc/version" ]] && grep -q "Microsoft\|WSL" /proc/version 2>/dev/null; then
     # WSL - use Linux-style path but make sure it exists
     DEFAULT_BIN_DIR="$HOME/.local/bin"
@@ -70,20 +70,20 @@ else
     DEFAULT_BIN_DIR="$HOME/.local/bin"
 fi
 
-GOOSE_BIN_DIR="${GOOSE_BIN_DIR:-$DEFAULT_BIN_DIR}"
+LEAF_BIN_DIR="${LEAF_BIN_DIR:-$DEFAULT_BIN_DIR}"
 RELEASE="${CANARY:-false}"
 CONFIGURE="${CONFIGURE:-true}"
-if [ -n "${GOOSE_VERSION:-}" ]; then
+if [ -n "${LEAF_VERSION:-}" ]; then
   # Validate the version format
-  if [[ ! "$GOOSE_VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
-    echo "[error]: invalid version '$GOOSE_VERSION'."
+  if [[ ! "$LEAF_VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+    echo "[error]: invalid version '$LEAF_VERSION'."
     echo "  expected: semver format vX.Y.Z, vX.Y.Z-suffix, or X.Y.Z"
     exit 1
   fi
-  GOOSE_VERSION=$(echo "$GOOSE_VERSION" | sed 's/^v\{0,1\}/v/') # Ensure the version string is prefixed with 'v' if not already present
-  RELEASE_TAG="$GOOSE_VERSION"
+  LEAF_VERSION=$(echo "$LEAF_VERSION" | sed 's/^v\{0,1\}/v/') # Ensure the version string is prefixed with 'v' if not already present
+  RELEASE_TAG="$LEAF_VERSION"
 else
-  # If GOOSE_VERSION is not set, fall back to existing behavior for backwards compatibility
+  # If LEAF_VERSION is not set, fall back to existing behavior for backwards compatibility
   RELEASE_TAG="$([[ "$RELEASE" == "true" ]] && echo "canary" || echo "stable")"
 fi
 
@@ -145,7 +145,7 @@ case "$OS" in
     OS="windows"
     ;;
   *)
-    echo "Error: Unsupported OS '$OS'. goose currently supports Linux, macOS, and Windows."
+    echo "Error: Unsupported OS '$OS'. leaf currently supports Linux, macOS, and Windows."
     exit 1
     ;;
 esac
@@ -176,7 +176,7 @@ echo "Detected OS: $OS with ARCH $ARCH"
 
 # Build the filename and URL for the stable release
 if [ "$OS" = "darwin" ]; then
-  FILE="goose-$ARCH-apple-darwin.tar.bz2"
+  FILE="leaf-$ARCH-apple-darwin.tar.bz2"
   EXTRACT_CMD="tar"
 elif [ "$OS" = "windows" ]; then
   # Windows only supports x86_64 currently
@@ -184,22 +184,22 @@ elif [ "$OS" = "windows" ]; then
     echo "Error: Windows currently only supports x86_64 architecture."
     exit 1
   fi
-  FILE="goose-$ARCH-pc-windows-msvc.zip"
+  FILE="leaf-$ARCH-pc-windows-msvc.zip"
   EXTRACT_CMD="unzip"
-  OUT_FILE="goose.exe"
+  OUT_FILE="leaf.exe"
 else
-  FILE="goose-$ARCH-unknown-linux-gnu.tar.bz2"
+  FILE="leaf-$ARCH-unknown-linux-gnu.tar.bz2"
   EXTRACT_CMD="tar"
 fi
 
 DOWNLOAD_URL="https://github.com/$REPO/releases/download/$RELEASE_TAG/$FILE"
 
-# --- 4) Download & extract 'goose' binary ---
+# --- 4) Download & extract 'leaf' binary ---
 echo "Downloading $RELEASE_TAG release: $FILE..."
 if ! curl -sLf "$DOWNLOAD_URL" --output "$FILE"; then
   # If the download fails, only fall back to latest stable when no version was specified and canary was not requested).
-  if ! [ -n "${GOOSE_VERSION:-}" ] && [ "${CANARY:-false}" != "true" ]; then
-    LATEST_TAG=$(curl -s https://api.github.com/repos/block/goose/releases/latest | \
+  if ! [ -n "${LEAF_VERSION:-}" ] && [ "${CANARY:-false}" != "true" ]; then
+    LATEST_TAG=$(curl -s https://api.github.com/repos/LeafAI/Leaf/releases/latest | \
       grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
     if [ -z "$LATEST_TAG" ]; then
       echo "Error: Failed to download $DOWNLOAD_URL and latest tag unavailable"
@@ -221,7 +221,7 @@ if ! curl -sLf "$DOWNLOAD_URL" --output "$FILE"; then
 fi
 
 # Create a temporary directory for extraction
-TMP_DIR="/tmp/goose_install_$RANDOM"
+TMP_DIR="/tmp/leaf_install_$RANDOM"
 if ! mkdir -p "$TMP_DIR"; then
   echo "Error: Could not create temporary extraction directory"
   exit 1
@@ -268,31 +268,59 @@ set -e  # Re-enable immediate exit on error
 rm "$FILE" # clean up the downloaded archive
 
 # Determine the extraction directory (handle subdirectory in Windows packages)
-# Windows releases may contain files in a 'goose-package' subdirectory
+# Windows releases may contain files in a 'leaf-package' subdirectory
 EXTRACT_DIR="$TMP_DIR"
-if [ "$OS" = "windows" ] && [ -d "$TMP_DIR/goose-package" ]; then
-  echo "Found goose-package subdirectory, using that as extraction directory"
-  EXTRACT_DIR="$TMP_DIR/goose-package"
+if [ "$OS" = "windows" ] && [ -d "$TMP_DIR/leaf-package" ]; then
+  echo "Found leaf-package subdirectory, using that as extraction directory"
+  EXTRACT_DIR="$TMP_DIR/leaf-package"
 fi
 
 # Make binary executable
 if [ "$OS" = "windows" ]; then
-  chmod +x "$EXTRACT_DIR/goose.exe"
+  chmod +x "$EXTRACT_DIR/leaf.exe"
 else
-  chmod +x "$EXTRACT_DIR/goose"
+  chmod +x "$EXTRACT_DIR/leaf"
 fi
 
-# --- 5) Install to $GOOSE_BIN_DIR ---
-if [ ! -d "$GOOSE_BIN_DIR" ]; then
-  echo "Creating directory: $GOOSE_BIN_DIR"
-  mkdir -p "$GOOSE_BIN_DIR"
+# --- 5) Install to $LEAF_BIN_DIR ---
+if [ ! -d "$LEAF_BIN_DIR" ]; then
+  echo "Creating directory: $LEAF_BIN_DIR"
+  mkdir -p "$LEAF_BIN_DIR"
 fi
 
-echo "Moving goose to $GOOSE_BIN_DIR/$OUT_FILE"
+echo "Moving leaf to $LEAF_BIN_DIR/$OUT_FILE"
 if [ "$OS" = "windows" ]; then
-  mv "$EXTRACT_DIR/goose.exe" "$GOOSE_BIN_DIR/$OUT_FILE"
+  # On Linux, if the target binary is currently running, writing to it fails
+  # with ETXTBSY ("Text file busy"). Rename the old binary out of the way
+  # first, then move the new one in. If the move fails, restore the old binary
+  # so the user is never left without an executable.
+  if [ -f "$LEAF_BIN_DIR/$OUT_FILE" ]; then
+    mv "$LEAF_BIN_DIR/$OUT_FILE" "$LEAF_BIN_DIR/$OUT_FILE.old"
+    if ! mv "$EXTRACT_DIR/leaf.exe" "$LEAF_BIN_DIR/$OUT_FILE"; then
+      echo "Error: failed to install new binary, restoring previous version"
+      mv "$LEAF_BIN_DIR/$OUT_FILE.old" "$LEAF_BIN_DIR/$OUT_FILE"
+      exit 1
+    fi
+    rm -f "$LEAF_BIN_DIR/$OUT_FILE.old"
+  else
+    mv "$EXTRACT_DIR/leaf.exe" "$LEAF_BIN_DIR/$OUT_FILE"
+  fi
 else
-  mv "$EXTRACT_DIR/goose" "$GOOSE_BIN_DIR/$OUT_FILE"
+  # On Linux, if the target binary is currently running, writing to it fails
+  # with ETXTBSY ("Text file busy"). Rename the old binary out of the way
+  # first, then move the new one in. If the move fails, restore the old binary
+  # so the user is never left without an executable.
+  if [ -f "$LEAF_BIN_DIR/$OUT_FILE" ]; then
+    mv "$LEAF_BIN_DIR/$OUT_FILE" "$LEAF_BIN_DIR/$OUT_FILE.old"
+    if ! mv "$EXTRACT_DIR/leaf" "$LEAF_BIN_DIR/$OUT_FILE"; then
+      echo "Error: failed to install new binary, restoring previous version"
+      mv "$LEAF_BIN_DIR/$OUT_FILE.old" "$LEAF_BIN_DIR/$OUT_FILE"
+      exit 1
+    fi
+    rm -f "$LEAF_BIN_DIR/$OUT_FILE.old"
+  else
+    mv "$EXTRACT_DIR/leaf" "$LEAF_BIN_DIR/$OUT_FILE"
+  fi
 fi
 
 # Copy Windows runtime DLLs if they exist
@@ -300,31 +328,32 @@ if [ "$OS" = "windows" ]; then
   for dll in "$EXTRACT_DIR"/*.dll; do
     if [ -f "$dll" ]; then
       echo "Moving Windows runtime DLL: $(basename "$dll")"
-      mv "$dll" "$GOOSE_BIN_DIR/"
+      mv "$dll" "$LEAF_BIN_DIR/"
     fi
   done
 fi
 
 # skip configuration for non-interactive installs e.g. automation, docker
 if [ "$CONFIGURE" = true ]; then
-  # --- 6) Configure goose (Optional) ---
+  # --- 6) Configure leaf (Optional) ---
   echo ""
-  echo "Configuring goose"
+  echo "Configuring leaf"
   echo ""
-  "$GOOSE_BIN_DIR/$OUT_FILE" configure
+  "$LEAF_BIN_DIR/$OUT_FILE" configure
 else
-  echo "Skipping 'goose configure', you may need to run this manually later"
+  echo "Skipping 'leaf configure', you may need to run this manually later"
 fi
 
 
 
+
 # --- 7) Check PATH and give instructions if needed ---
-if [[ ":$PATH:" != *":$GOOSE_BIN_DIR:"* ]]; then
+if [[ ":$PATH:" != *":$LEAF_BIN_DIR:"* ]]; then
   echo ""
-  echo "Warning: goose installed, but $GOOSE_BIN_DIR is not in your PATH."
+  echo "Warning: leaf installed, but $LEAF_BIN_DIR is not in your PATH."
 
   if [ "$OS" = "windows" ]; then
-    echo "To add goose to your PATH in PowerShell:"
+    echo "To add leaf to your PATH in PowerShell:"
     echo ""
     echo "# Add to your PowerShell profile"
     echo '$profilePath = $PROFILE'
@@ -334,13 +363,13 @@ if [[ ":$PATH:" != *":$GOOSE_BIN_DIR:"* ]]; then
     echo '. $PROFILE'
     echo ""
     echo "Alternatively, you can run:"
-    echo "    goose configure"
+    echo "    leaf configure"
     echo "or rerun this install script after updating your PATH."
   else
     SHELL_NAME=$(basename "$SHELL")
 
     echo ""
-    echo "The \$GOOSE_BIN_DIR is not in your PATH."
+    echo "The \$LEAF_BIN_DIR is not in your PATH."
 
     if [ "$CONFIGURE" = true ]; then
       echo "What would you like to do?"
@@ -362,23 +391,23 @@ if [[ ":$PATH:" != *":$GOOSE_BIN_DIR:"* ]]; then
       case "$choice" in
       1)
         RC_FILE="$HOME/.${SHELL_NAME}rc"
-        echo "Adding \$GOOSE_BIN_DIR to $RC_FILE..."
-        echo "export PATH=\"$GOOSE_BIN_DIR:\$PATH\"" >> "$RC_FILE"
+        echo "Adding \$LEAF_BIN_DIR to $RC_FILE..."
+        echo "export PATH=\"$LEAF_BIN_DIR:\$PATH\"" >> "$RC_FILE"
         echo "Done! Reload your shell or run 'source $RC_FILE' to apply changes."
         ;;
       2)
         echo ""
         echo "Add it to your PATH by editing ~/.${SHELL_NAME}rc or similar:"
-        echo "    export PATH=\"$GOOSE_BIN_DIR:\$PATH\""
+        echo "    export PATH=\"$LEAF_BIN_DIR:\$PATH\""
         echo "Then reload your shell (e.g. 'source ~/.${SHELL_NAME}rc') to apply changes."
         ;;
       *)
-        echo "Invalid choice. Please add \$GOOSE_BIN_DIR to your PATH manually."
+        echo "Invalid choice. Please add \$LEAF_BIN_DIR to your PATH manually."
         ;;
       esac
     else
       echo ""
-      echo "Configure disabled. Please add \$GOOSE_BIN_DIR to your PATH manually."
+      echo "Configure disabled. Please add \$LEAF_BIN_DIR to your PATH manually."
     fi
 
   fi


### PR DESCRIPTION
## Summary

Syncs CLI-relevant commits from upstream block/goose main branch (928f4ac46..59a96c986).

## Commits Applied (8 total)

| # | Upstream Commit | Description |
|---|-----------------|-------------|
| 1 | `59a96c986` | gemini acp: add configure_subprocess() to prevent terminal windows |
| 2 | `ef3980a32` | Linux ETXTBSY fix + goose→leaf rename in download_cli.sh |
| 3 | `09879ed67` | Model context_limit: prioritize predefined over canonical registry |
| 4 | `8cd04aa76` | cursor-agent: always pass --model to CLI |
| 5 | `03f546bd1` | skip_canonical_filtering for declarative providers |
| 6 | `984967141` | text+image: preserve order when message contains both |
| 7 | `a47add0a8` | LiteLLM: parse nested usage payloads + cache tokens |
| 8 | `caef9f646` | native-tls: add optional native-tls as alternative to rustls |

## Files Changed

- `download_cli.sh` - goose→leaf rename + ETXTBSY fix
- `crates/leaf/src/acp/provider.rs` - configure_subprocess()
- `crates/leaf/src/model.rs` - context_limit priority
- `crates/leaf/src/providers/cursor_agent.rs` - --model flag
- `crates/leaf/src/config/declarative_providers.rs` - skip_canonical_filtering
- `crates/leaf/src/providers/base.rs` - skip_canonical_filtering() + cache tokens
- `crates/leaf/src/providers/formats/openai.rs` - text+image fix + nested usage
- `crates/leaf/src/providers/opencode.rs` - skip_canonical_filtering field
- `crates/leaf-server/Cargo.toml` - rustls-tls/native-tls features
- `crates/leaf-server/src/lib.rs` - TLS compile_error macros
- `crates/leaf-server/src/tls.rs` - dual TLS backend support
- `crates/leaf-server/src/commands/agent.rs` - conditional TLS binding
- `crates/leaf-server/src/tunnel/lapstone.rs` - rustls-tls conditional

## Skipped Commits (from issue #14)

- `d2553978c` - Onboarding flow (server-only)
- `8615853a8` - npm publishing workflow
- `3a9805e25` - Blog docs
- `5b4dd4059` - pnpm publishing fixes
- `70003c2e2` - Sandbox docs clarification
- `6098c80db` - Maverick recipe fix
- `772e37fb5` - AWS provider feature-gate
- `18bc030e4`, `6b14cff5f`, `21bc46258` - CI/publishing fixes
- `9c166954d` - proc-macro-error warning ignore
- `423e6ccd1` - Version/release commits
- `d76502970`, `b75ca5e41`, `4c4cebb41` - Version bumps

## Verification

- `cargo fmt` ✅
- `cargo check -p leaf-server --features rustls-tls` ✅
- `cargo clippy -p leaf-server --features rustls-tls` ✅ (pre-existing warnings allowed)

## Notes

- api_client.rs TLS changes (convert_key_to_pkcs8_pem) deferred from caef9f646 as they require additional dependencies in leaf crate