### PR TITLE
feat: adopt upstream CLI commits (per-delegate max_turns, Tanzu provider)

### DIFF
--- a/crates/leaf/src/agents/platform_extensions/summon.rs
+++ b/crates/leaf/src/agents/platform_extensions/summon.rs
@@ -110,6 +110,7 @@ pub struct DelegateParams {
     pub provider: Option<String>,
     pub model: Option<String>,
     pub temperature: Option<f32>,
+    pub max_turns: Option<usize>,
     #[serde(default)]
     pub r#async: bool,
 }
@@ -624,6 +625,11 @@ impl SummonClient {
                 "temperature": {
                     "type": "number",
                     "description": "Override temperature."
+                },
+                "max_turns": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Maximum turns for this delegate. Overrides recipe settings.max_turns and LEAF_SUBAGENT_MAX_TURNS."
                 },
                 "async": {
                     "type": "boolean",
@@ -1202,16 +1208,7 @@ impl SummonClient {
             .map(|args| serde_json::from_value(serde_json::Value::Object(args)))
             .transpose()
             .map_err(|e| format!("Invalid parameters: {}", e))?
-            .unwrap_or(DelegateParams {
-                instructions: None,
-                source: None,
-                parameters: None,
-                extensions: None,
-                provider: None,
-                model: None,
-                temperature: None,
-                r#async: false,
-            });
+            .unwrap_or_default();
 
         self.validate_delegate_params(&params)?;
 
@@ -1294,6 +1291,12 @@ impl SummonClient {
 
         if params.parameters.is_some() && params.source.is_none() {
             return Err("'parameters' can only be used with 'source'".to_string());
+        }
+
+        if let Some(max) = params.max_turns {
+            if max < 1 {
+                return Err("'max_turns' must be at least 1".to_string());
+            }
         }
 
         Ok(())
@@ -1534,7 +1537,18 @@ impl SummonClient {
             }
         }
 
-        let max_turns = self.resolve_max_turns(session);
+        let max_turns = params
+            .max_turns
+            .or_else(|| recipe.settings.as_ref().and_then(|s| s.max_turns))
+            .unwrap_or_else(|| self.resolve_max_turns(session));
+
+        if max_turns == 0 || max_turns > u32::MAX as usize {
+            anyhow::bail!(
+                "max_turns must be between 1 and {} (got {})",
+                u32::MAX,
+                max_turns
+            );
+        }
 
         let task_config = TaskConfig::new(provider, &session.id, &session.working_dir, extensions)
             .with_max_turns(Some(max_turns));
@@ -1588,16 +1602,15 @@ impl SummonClient {
     }
 
     fn resolve_max_turns(&self, session: &crate::session::Session) -> usize {
-        // Priority: env var > recipe settings > config.yaml > default
-        std::env::var("LEAF_SUBAGENT_MAX_TURNS")
-            .ok()
-            .and_then(|v| v.parse().ok())
+        session
+            .recipe
+            .as_ref()
+            .and_then(|r| r.settings.as_ref())
+            .and_then(|s| s.max_turns)
             .or_else(|| {
-                session
-                    .recipe
-                    .as_ref()
-                    .and_then(|r| r.settings.as_ref())
-                    .and_then(|s| s.max_turns)
+                std::env::var("LEAF_SUBAGENT_MAX_TURNS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
             })
             .or_else(|| {
                 Config::global()
@@ -2282,12 +2295,7 @@ You review code."#;
         let make_params = |source: Option<&str>, instructions: Option<&str>| DelegateParams {
             source: source.map(String::from),
             instructions: instructions.map(String::from),
-            parameters: None,
-            extensions: None,
-            provider: None,
-            model: None,
-            temperature: None,
-            r#async: false,
+            ..Default::default()
         };
 
         assert_eq!(

--- a/crates/leaf/src/config/declarative_providers.rs
+++ b/crates/leaf/src/config/declarative_providers.rs
@@ -36,6 +36,7 @@ pub struct EnvVarConfig {
     pub secret: bool,
     pub description: Option<String>,
     pub default: Option<String>,
+    pub primary: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -453,7 +454,7 @@ mod tests {
         let config: DeclarativeProviderConfig =
             serde_json::from_str(json).expect("tanzu.json should parse");
         assert_eq!(config.name, "tanzu_ai");
-        assert_eq!(config.display_name, "Tanzu AI Services");
+        assert_eq!(config.display_name, "VMware Tanzu Platform");
         assert!(matches!(config.engine, ProviderEngine::OpenAI));
         assert_eq!(config.api_key_env, "TANZU_AI_API_KEY");
         assert_eq!(
@@ -461,13 +462,16 @@ mod tests {
             "${TANZU_AI_ENDPOINT}/openai/v1/chat/completions"
         );
         assert_eq!(config.dynamic_models, Some(true));
-        assert_eq!(config.supports_streaming, Some(false));
+        assert_eq!(config.supports_streaming, Some(true));
 
         let env_vars = config.env_vars.as_ref().expect("env_vars should be set");
-        assert_eq!(env_vars.len(), 1);
+        assert_eq!(env_vars.len(), 2);
         assert_eq!(env_vars[0].name, "TANZU_AI_ENDPOINT");
         assert!(env_vars[0].required);
         assert!(!env_vars[0].secret);
+        assert_eq!(env_vars[1].name, "TANZU_AI_STREAMING");
+        assert!(!env_vars[1].required);
+        assert_eq!(env_vars[1].default, Some("true".to_string()));
 
         assert_eq!(config.models.len(), 1);
         assert_eq!(config.models[0].name, "openai/gpt-oss-120b");
@@ -492,6 +496,7 @@ mod tests {
             secret: false,
             description: None,
             default: None,
+            primary: None,
         }];
 
         let result = expand_env_vars("${TEST_EXPAND_HOST}/v1/chat/completions", &env_vars).unwrap();
@@ -508,6 +513,7 @@ mod tests {
             secret: false,
             description: None,
             default: None,
+            primary: None,
         }];
 
         let result = expand_env_vars("${TEST_EXPAND_MISSING}/path", &env_vars);
@@ -528,6 +534,7 @@ mod tests {
             secret: false,
             description: None,
             default: Some("https://fallback.example.com".to_string()),
+            primary: None,
         }];
 
         let result =
@@ -543,6 +550,7 @@ mod tests {
             secret: false,
             description: None,
             default: None,
+            primary: None,
         }];
 
         let result =
@@ -566,6 +574,7 @@ mod tests {
             secret: false,
             description: None,
             default: Some("https://from-default.com".to_string()),
+            primary: None,
         }];
 
         let result = expand_env_vars("${TEST_EXPAND_OVERRIDE}/path", &env_vars).unwrap();

--- a/crates/leaf/src/providers/declarative/tanzu.json
+++ b/crates/leaf/src/providers/declarative/tanzu.json
@@ -1,8 +1,8 @@
 {
   "name": "tanzu_ai",
   "engine": "openai",
-  "display_name": "Tanzu AI Services",
-  "description": "Enterprise-managed LLM access through VMware Tanzu Platform AI Services",
+  "display_name": "VMware Tanzu Platform",
+  "description": "Enterprise-managed LLM access through AI Services on VMware Tanzu Platform.",
   "api_key_env": "TANZU_AI_API_KEY",
   "base_url": "${TANZU_AI_ENDPOINT}/openai/v1/chat/completions",
   "env_vars": [
@@ -10,12 +10,20 @@
       "name": "TANZU_AI_ENDPOINT",
       "required": true,
       "secret": false,
-      "description": "Your Tanzu AI Services endpoint URL"
+      "description": "Your VMware Tanzu Platform AI Services endpoint URL"
+    },
+    {
+      "name": "TANZU_AI_STREAMING",
+      "required": false,
+      "secret": false,
+      "primary": true,
+      "default": "true",
+      "description": "Enable streaming responses (true/false)"
     }
   ],
   "dynamic_models": true,
   "models": [
     { "name": "openai/gpt-oss-120b", "context_limit": 131072 }
   ],
-  "supports_streaming": false
+  "supports_streaming": true
 }


### PR DESCRIPTION
## Summary

Adopt upstream CLI-relevant commits from block/goose:

### Commits Adopted:

1. **per-delegate max_turns override** (`838d99e04`)
   - Add `max_turns` field to `DelegateParams` struct
   - Allows delegates to override max_turns setting per-call
   - Priority: params.max_turns > recipe settings > env var > config > default

2. **VMware Tanzu Platform provider updates** (`c93651401`)
   - Add `primary` field to `EnvVarConfig` for UI display control
   - Update Tanzu provider: display name, streaming support, new streaming env var

### Skipped:
- Gemini OAuth provider (complex provider restructure)
- Developer MCP server enhancements (empty/merge commit)

## Testing
- [x] cargo fmt passes
- [x] cargo check -p leaf passes

Co-authored-by: Michael Yagi <myagi@ascentrivals.com>
Co-authored-by: Douwe Osinga <douwe@squareup.com>
Co-authored-by: Nick Kuhn <nick.kuhn@broadcom.com>