### PR TITLE
fix: opentelemetry build fails without telemetry feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3858,7 +3858,8 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.31.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=345cd74a#345cd74a9c88ad1a47435d3d063c12d47235e803"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3871,7 +3872,8 @@ dependencies = [
 [[package]]
 name = "opentelemetry-appender-tracing"
 version = "0.31.1"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=345cd74a#345cd74a9c88ad1a47435d3d063c12d47235e803"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -3882,19 +3884,21 @@ dependencies = [
 [[package]]
 name = "opentelemetry-http"
 version = "0.31.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=345cd74a#345cd74a9c88ad1a47435d3d063c12d47235e803"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.13.2",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=345cd74a#345cd74a9c88ad1a47435d3d063c12d47235e803"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http",
  "opentelemetry",
@@ -3902,14 +3906,16 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.2",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
 version = "0.31.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=345cd74a#345cd74a9c88ad1a47435d3d063c12d47235e803"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3921,7 +3927,8 @@ dependencies = [
 [[package]]
 name = "opentelemetry-stdout"
 version = "0.31.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=345cd74a#345cd74a9c88ad1a47435d3d063c12d47235e803"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8887887e169414f637b18751487cce4e095be787d23fad13c454e2fb1b3811"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -3931,17 +3938,18 @@ dependencies = [
 [[package]]
 name = "opentelemetry_sdk"
 version = "0.31.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=345cd74a#345cd74a9c88ad1a47435d3d063c12d47235e803"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "portable-atomic",
  "rand 0.9.2",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ url = "2.5.8"
 opentelemetry = "0.31"
 opentelemetry_sdk = { version = "0.31", features = ["metrics"] }
 opentelemetry-otlp = "0.31"
-opentelemetry-appender-tracing = { version = "0.31", features = ["experimental_span_attributes"] }
+opentelemetry-appender-tracing = { version = "0.31" }
 opentelemetry-stdout = { version = "0.31", features = ["trace", "metrics", "logs"] }
 tracing-futures = { version = "0.2", features = ["futures-03"] }
 tracing-opentelemetry = "0.32"

--- a/crates/leaf-test-support/Cargo.toml
+++ b/crates/leaf-test-support/Cargo.toml
@@ -7,10 +7,13 @@ license.workspace = true
 repository.workspace = true
 description.workspace = true
 
+[features]
+telemetry = ["dep:opentelemetry"]
+
 [dependencies]
 axum = { workspace = true }
 env-lock = { workspace = true }
-opentelemetry = { workspace = true }
+opentelemetry = { workspace = true, optional = true }
 rmcp = { workspace = true, features = ["server", "macros", "transport-streamable-http-server"] }
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/leaf-test-support/src/lib.rs
+++ b/crates/leaf-test-support/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod mcp;
+#[cfg(feature = "telemetry")]
 pub mod otel;
 pub mod session;
 


### PR DESCRIPTION
## Problem

`cargo build` fails with:

```
error: failed to select a version for `opentelemetry-appender-tracing`.
    ... required by package `leaf v1.28.0 (/data/src/oss/leaf/crates/leaf)`
```

Two issues:

1. `opentelemetry-appender-tracing` in workspace `Cargo.toml` specifies non-existent feature `experimental_span_attributes`
2. `leaf-test-support` unconditionally depends on `opentelemetry`, forcing resolution of the entire opentelemetry crate chain even when `telemetry` feature is disabled

## Fix

- Remove non-existent `experimental_span_attributes` feature from workspace `Cargo.toml`
- Make `opentelemetry` optional in `leaf-test-support` behind a `telemetry` feature flag
- Gate the `otel` module in `leaf-test-support` with `#[cfg(feature = "telemetry")]`

Closes #19