### PR TITLE
feat(cli): add -i short flag and visible --id alias for --session-id

### DIFF
--- a/crates/leaf-cli/src/cli.rs
+++ b/crates/leaf-cli/src/cli.rs
@@ -61,7 +61,8 @@ pub struct Identifier {
 
     #[arg(
         long = "session-id",
-        alias = "id",
+        short = 'i',
+        visible_alias = "id",
         value_name = "SESSION_ID",
         help = "Session ID (e.g., '20250921_143022')",
         long_help = "Specify a session ID directly. When used with --resume, will resume this specific session if it exists."


### PR DESCRIPTION
## Summary

Adds a short flag `-i` and makes the `--id` alias visible in help for `--session-id`.

### Before
```
--session-id <SESSION_ID>    # only long form visible, --id was hidden alias
```

### After
```
-i, --session-id <SESSION_ID>  [aliases: --id]
```

### Usage
```bash
leaf session -r -i 20250921_143022
leaf session -r --id 20250921_143022
```

### Why `-i`?
- `-s` is already taken by `--interactive` in `leaf run` and is the subcommand alias for `leaf session`
- `-i` is mnemonic for "ID" and has no conflicts across any subcommand

Closes #26

## Checklist
- [x] `cargo fmt` passes
- [x] `cargo check -p leaf-cli` passes
- [x] `cargo clippy -p leaf-cli -- -D warnings` passes