### PR TITLE
feat: render diagram code blocks as ASCII art via Kroki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,7 +149,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -142,7 +160,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -170,6 +188,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +215,15 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -262,6 +300,49 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey 0.1.1",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "aws-lc-rs"
@@ -498,6 +579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitstream-io"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+dependencies = [
+ "core2",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +662,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
@@ -1083,6 +1179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1432,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "dbus"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,7 +1595,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1616,6 +1727,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcb71a32ab9582e2756554e84b24aee90d7187034049c35921ec3296b70c13ad"
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,7 +1770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1667,6 +1798,15 @@ checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1804,6 +1944,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "fluent-uri"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,6 +1988,29 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32eac81c1135c1df01d4e6d4233c47ba11f6a6d07f33e0bba09d18797077770"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -2570,20 +2739,48 @@ dependencies = [
  "bytemuck",
  "byteorder-lite",
  "color_quant",
+ "exr",
  "gif 0.14.1",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
  "tiff 0.11.3",
  "zune-core",
  "zune-jpeg",
 ]
 
 [[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imagesize"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
+
+[[package]]
 name = "imagesize"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+
+[[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "include_dir"
@@ -2661,6 +2858,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,7 +2936,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2939,6 +3147,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2991,7 +3210,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
- "pastey",
+ "pastey 0.2.1",
  "pulldown-cmark",
  "rand 0.8.5",
  "rayon",
@@ -3110,6 +3329,7 @@ dependencies = [
  "dotenvy",
  "etcetera 0.11.0",
  "futures",
+ "image 0.25.10",
  "indicatif",
  "leaf",
  "leaf-acp",
@@ -3118,6 +3338,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest 0.13.2",
+ "resvg",
  "rmcp 1.2.0",
  "rustyline",
  "serde",
@@ -3267,6 +3488,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3329,6 +3560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lopdf"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3389,6 +3629,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3403,6 +3653,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memo-map"
@@ -3527,6 +3786,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3580,12 +3845,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4015,6 +4286,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "pastey"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4114,6 +4397,12 @@ dependencies = [
  "pest",
  "sha2",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -4339,6 +4628,25 @@ dependencies = [
  "tokio",
  "tracing",
  "windows 0.62.2",
+]
+
+[[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4609,6 +4917,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4836,6 +5194,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "944d052815156ac8fa77eaac055220e95ba0b01fa8887108ca710c03805d9051"
+dependencies = [
+ "gif 0.13.3",
+ "jpeg-decoder",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4868,7 +5242,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "futures",
- "pastey",
+ "pastey 0.2.1",
  "pin-project-lite",
  "rmcp-macros 0.12.0",
  "schemars",
@@ -4895,7 +5269,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "oauth2",
- "pastey",
+ "pastey 0.2.1",
  "pin-project-lite",
  "process-wrap",
  "rand 0.10.0",
@@ -4962,6 +5336,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5022,7 +5402,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5081,7 +5461,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5107,6 +5487,22 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "rustyline"
@@ -5711,6 +6107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5735,10 +6140,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -5762,7 +6191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6010,6 +6439,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6052,6 +6490,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -6164,7 +6612,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6383,6 +6831,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.17.16",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -6904,6 +7378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+
+[[package]]
 name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6965,7 +7445,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hmac",
  "html_parser",
- "imagesize",
+ "imagesize 0.14.0",
  "lazy_static",
  "md-5",
  "quick-xml 0.37.5",
@@ -6987,6 +7467,18 @@ name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
 
 [[package]]
 name = "unicode-ident"
@@ -7016,10 +7508,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
@@ -7075,6 +7579,33 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "usvg"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84ea542ae85c715f07b082438a4231c3760539d902e11d093847a0b22963032"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize 0.12.0",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
 
 [[package]]
 name = "utf-8"
@@ -7139,6 +7670,17 @@ dependencies = [
  "outref",
  "uuid",
  "vsimd",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7436,7 +7978,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8094,10 +8636,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
 name = "xterm-color"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7008a9d8ba97a7e47d9b2df63fcdb8dade303010c5a7cd5bf2469d4da6eba673"
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yaml-rust2"

--- a/crates/leaf-cli/Cargo.toml
+++ b/crates/leaf-cli/Cargo.toml
@@ -31,6 +31,8 @@ dotenvy = { workspace = true }
 bat = { version = "0.26.1", default-features = false, features = ["regex-onig"] }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
+resvg = "0.42"
+image = "0.25"
 tokio = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }

--- a/crates/leaf-cli/src/lib.rs
+++ b/crates/leaf-cli/src/lib.rs
@@ -6,6 +6,7 @@ pub mod recipes;
 pub mod scenario_tests;
 pub mod session;
 pub mod signal;
+pub mod sixel;
 
 // Re-export commonly used types
 pub use cli::Cli;

--- a/crates/leaf-cli/src/logging.rs
+++ b/crates/leaf-cli/src/logging.rs
@@ -126,7 +126,6 @@ fn setup_logging_internal(name: Option<&str>, force: bool, verbose: bool) -> Res
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::env;
     use tempfile::TempDir;
 

--- a/crates/leaf-cli/src/session/output.rs
+++ b/crates/leaf-cli/src/session/output.rs
@@ -12,6 +12,7 @@ use leaf::providers::canonical::maybe_get_canonical_model;
 use leaf::subprocess::SubprocessExt;
 use leaf::utils::safe_truncate;
 use rmcp::model::{CallToolRequestParams, JsonObject, PromptArgument};
+use serde::Deserialize;
 use serde_json::Value;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -969,6 +970,20 @@ pub fn env_no_color() -> bool {
 
 fn print_markdown(content: &str, theme: Theme) {
     if std::io::stdout().is_terminal() {
+        if let Some(_) = get_kroki_url() {
+            if let Some((before, diagram_src, diagram_type, after)) = extract_diagram_block(content)
+            {
+                if !before.is_empty() {
+                    print_markdown(&before, theme);
+                }
+                print_diagram(&diagram_src, diagram_type);
+                if !after.is_empty() {
+                    print_markdown(&after, theme);
+                }
+                return;
+            }
+        }
+
         if let Some((before, table, after)) = extract_markdown_table(content) {
             if !before.is_empty() {
                 print_markdown_raw(&before, theme);
@@ -995,6 +1010,191 @@ fn print_markdown_raw(content: &str, theme: Theme) {
         .wrapping_mode(WrappingMode::NoWrapping(true))
         .print()
         .unwrap();
+}
+
+/// Diagram languages Kroki can render as SVG.
+const KROKI_DIAGRAM_TYPES: &[&str] = &[
+    "mermaid",
+    "plantuml",
+    "dot",
+    "graphviz",
+    "d2",
+    "excalidraw",
+    "bytefield",
+    "wavedrom",
+    "nomnoml",
+    "pikchr",
+    "structurizr",
+    "vega",
+    "vegalite",
+    "erd",
+    "svgbob",
+    "umlet",
+    "wireviz",
+    "blockdiag",
+    "seqdiag",
+    "actdiag",
+    "nwdiag",
+    "packetdiag",
+    "rackdiag",
+    "c4plantuml",
+];
+
+fn get_kroki_url() -> Option<String> {
+    Config::global()
+        .get_param::<KrokiConfig>("kroki")
+        .ok()
+        .and_then(|c| c.url)
+        .filter(|s| !s.is_empty())
+}
+
+#[derive(Deserialize)]
+struct KrokiConfig {
+    url: Option<String>,
+    proxy: Option<String>,
+}
+
+fn get_kroki_proxy() -> Option<String> {
+    Config::global()
+        .get_param::<KrokiConfig>("kroki")
+        .ok()
+        .and_then(|c| c.proxy)
+        .filter(|s| !s.is_empty())
+}
+
+fn terminal_size() -> (u16, u16) {
+    Term::stdout().size()
+}
+
+/// Extracts the first supported diagram code block from markdown.
+///
+/// Returns `(before_text, diagram_source, diagram_type, after_text)`.
+fn extract_diagram_block(content: &str) -> Option<(String, String, &str, String)> {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut in_code_block = false;
+    let mut fence_char = '\0';
+    let mut fence_len = 0;
+    let mut code_start = None;
+    let mut code_lang = None;
+    let mut code_end = None;
+
+    for line in &lines {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if !in_code_block {
+            let ch = trimmed.chars().next()?;
+            if ch != '`' && ch != '~' {
+                continue;
+            }
+            let len = trimmed.chars().take_while(|&c| c == ch).count();
+            if len < 3 {
+                continue;
+            }
+            let lang: Option<&str> = trimmed
+                .char_indices()
+                .nth(len)
+                .and_then(|(idx, _)| trimmed.get(idx..));
+            if KROKI_DIAGRAM_TYPES.contains(&lang.unwrap_or("").trim()) {
+                in_code_block = true;
+                fence_char = ch;
+                fence_len = len;
+                code_start = Some(lines.iter().position(|l| l.as_ptr() == line.as_ptr())?);
+                code_lang = Some(lang.unwrap_or("").trim());
+            }
+        } else {
+            let ch = trimmed.chars().next()?;
+            if ch == fence_char {
+                let len = trimmed.chars().take_while(|&c| c == fence_char).count();
+                if len >= fence_len {
+                    code_end = Some(lines.iter().position(|l| l.as_ptr() == line.as_ptr())?);
+                    break;
+                }
+            }
+        }
+    }
+
+    let start = code_start?;
+    let end = code_end?;
+    let lang = code_lang?;
+
+    let diagram_source = lines[start + 1..end].join("\n");
+    if diagram_source.trim().is_empty() {
+        return None;
+    }
+
+    let before = if start > 0 {
+        lines[..start].join("\n") + "\n"
+    } else {
+        String::new()
+    };
+    let after = if end + 1 < lines.len() {
+        "\n".to_string() + &lines[end + 1..].join("\n")
+    } else {
+        String::new()
+    };
+
+    Some((before, diagram_source, lang, after))
+}
+
+/// Renders a diagram via Kroki SVG endpoint and pipes to chafa.
+fn print_diagram(source: &str, diagram_type: &str) {
+    let kroki_url = match get_kroki_url() {
+        Some(url) => url,
+        None => return,
+    };
+
+    let endpoint = format!("{}/{}/svg", kroki_url.trim_end_matches('/'), diagram_type);
+
+    // Build client with optional proxy from config
+    let client = match get_kroki_proxy() {
+        Some(proxy_url) => {
+            let proxy = reqwest::Proxy::https(&proxy_url)
+                .or_else(|_| reqwest::Proxy::http(&proxy_url))
+                .unwrap_or_else(|_| panic!("Failed to parse proxy URL"));
+            reqwest::blocking::Client::builder()
+                .proxy(proxy)
+                .timeout(Duration::from_secs(15))
+                .build()
+                .unwrap_or_else(|_| reqwest::blocking::Client::new())
+        }
+        None => reqwest::blocking::Client::new(),
+    };
+
+    let response = client
+        .post(&endpoint)
+        .header("Content-Type", "text/plain")
+        .body(source.to_string())
+        .send();
+
+    let svg = match response {
+        Ok(resp) if resp.status().is_success() => resp.text().unwrap_or_default(),
+        Ok(resp) => {
+            eprintln!(
+                "  {} Kroki returned {} for {} diagram",
+                style("⚠").yellow(),
+                resp.status(),
+                diagram_type
+            );
+            println!("```{}\n{}\n```", diagram_type, source);
+            return;
+        }
+        Err(e) => {
+            eprintln!("  {} Failed to fetch diagram: {}", style("⚠").yellow(), e);
+            println!("```{}\n{}\n```", diagram_type, source);
+            return;
+        }
+    };
+
+    // Try Sixel rendering
+    let (cols, rows) = terminal_size();
+    let width = cols as u32 * 6;
+    let height = rows as u32 * 12;
+    match crate::sixel::render_svg_to_sixel(&svg, width, height) {
+        Ok(sixel) => print!("{}", sixel),
+        Err(_) => println!("```{}\n{}\n```", diagram_type, source),
+    }
 }
 
 fn extract_markdown_table(content: &str) -> Option<(String, Vec<&str>, &str)> {
@@ -1601,5 +1801,57 @@ mod tests {
             json!({"top_up_url": "https://router.tetrate.ai/billing"}),
         );
         assert_eq!(get_credits_top_up_url(&message), None);
+    }
+
+    #[test]
+    fn test_extract_diagram_block_mermaid() {
+        let content = "Here's a diagram:
+
+```mermaid
+flowchart TD
+    A --> B --> C
+```
+
+That's the diagram!";
+        let result = extract_diagram_block(content);
+        eprintln!("DEBUG: result = {:?}", result);
+        assert!(result.is_some(), "Should extract mermaid diagram");
+
+        let (before, source, diagram_type, after) = result.unwrap();
+        assert_eq!(diagram_type, "mermaid");
+        assert!(before.contains("Here's a diagram"));
+        assert!(after.contains("That's the diagram"));
+        assert!(source.contains("flowchart TD"));
+    }
+
+    #[test]
+    fn test_extract_diagram_block_graphviz() {
+        let content = "```graphviz
+digraph G { A -> B }
+```";
+        let result = extract_diagram_block(content);
+        assert!(result.is_some());
+        let (_, _, diagram_type, _) = result.unwrap();
+        assert_eq!(diagram_type, "graphviz");
+    }
+
+    #[test]
+    fn test_extract_diagram_block_no_diagram() {
+        let content = "```python
+print('hello')
+```";
+        let result = extract_diagram_block(content);
+        assert!(
+            result.is_none(),
+            "Non-diagram code blocks should not be extracted"
+        );
+    }
+
+    #[test]
+    fn test_extract_diagram_block_empty_source() {
+        let content = "```mermaid
+```";
+        let result = extract_diagram_block(content);
+        assert!(result.is_none(), "Empty diagram source should return None");
     }
 }

--- a/crates/leaf-cli/src/session/streaming_buffer.rs
+++ b/crates/leaf-cli/src/session/streaming_buffer.rs
@@ -24,10 +24,57 @@ use regex::Regex;
 use std::io::Write;
 use std::sync::LazyLock;
 
+/// Kroki-supported diagram types that should not be truncated.
+const KROKI_DIAGRAM_TYPES: &[&str] = &[
+    "mermaid",
+    "plantuml",
+    "dot",
+    "graphviz",
+    "d2",
+    "excalidraw",
+    "bytefield",
+    "wavedrom",
+    "nomnoml",
+    "pikchr",
+    "structurizr",
+    "vega",
+    "vegalite",
+    "erd",
+    "svgbob",
+];
+
 const MAX_CODE_BLOCK_LINES: usize = 50;
 const TRUNCATED_SHOW_LINES: usize = 20;
 
+/// Check if content starts with a Kroki-supported diagram code block.
+fn is_kroki_diagram_block(content: &str) -> bool {
+    let trimmed = content.trim_start();
+
+    // Check for ```lang\n pattern
+    if let Some(rest) = trimmed.strip_prefix("```") {
+        if let Some(nl_pos) = rest.find('\n') {
+            let lang = rest[..nl_pos].trim();
+            return KROKI_DIAGRAM_TYPES.contains(&lang);
+        }
+    }
+
+    // Check for ~~~lang\n pattern
+    if let Some(rest) = trimmed.strip_prefix("~~~") {
+        if let Some(nl_pos) = rest.find('\n') {
+            let lang = rest[..nl_pos].trim();
+            return KROKI_DIAGRAM_TYPES.contains(&lang);
+        }
+    }
+
+    false
+}
+
 fn truncate_code_blocks(content: &str) -> String {
+    // Kroki diagram blocks should not be truncated - they need to be rendered as-is
+    if is_kroki_diagram_block(content) {
+        return content.to_string();
+    }
+
     let (open_pos, fence) = match (content.find("```"), content.find("~~~")) {
         (Some(a), Some(b)) if a <= b => (a, "```"),
         (Some(a), None) => (a, "```"),
@@ -130,6 +177,15 @@ static INLINE_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
 #[derive(Default)]
 pub struct MarkdownBuffer {
     buffer: String,
+    /// True when currently inside a code block (updated on each push)
+    in_code_block: bool,
+}
+
+impl MarkdownBuffer {
+    /// Returns true if the buffer is currently inside a code block.
+    pub fn is_in_code_block(&self) -> bool {
+        self.in_code_block
+    }
 }
 
 /// Tracks the current parsing state for markdown constructs.
@@ -138,6 +194,8 @@ struct ParseState {
     in_code_block: bool,
     code_fence_char: char,
     code_fence_len: usize,
+    /// True when inside a Kroki-supported diagram code block (mermaid, plantuml, etc.)
+    in_kroki_diagram: bool,
     in_table: bool,
     pending_heading: bool,
     in_inline_code: bool,
@@ -163,6 +221,7 @@ impl ParseState {
             && !self.in_link_text
             && !self.in_link_url
             && !self.in_image_alt
+            && !self.in_kroki_diagram
     }
 }
 
@@ -183,14 +242,37 @@ impl MarkdownBuffer {
     /// contains only incomplete constructs. Large code blocks are automatically
     /// truncated with full content saved to a temp file.
     pub fn push(&mut self, chunk: &str) -> Option<String> {
+        let has_fence = chunk.contains("```") || chunk.contains("~~~");
+
+        // State machine for code blocks
+        if self.in_code_block {
+            // Currently inside a code block
+            if has_fence {
+                // Closing fence found - append chunk, flush buffer, and return
+                self.buffer.push_str(chunk);
+                self.in_code_block = false;
+                let result = self.buffer.clone();
+                self.buffer.clear();
+                return Some(truncate_code_blocks(&result));
+            }
+            // Still inside code block - buffer content
+            self.buffer.push_str(chunk);
+            return None;
+        }
+
+        // Not inside a code block
+        if has_fence {
+            // Opening fence found - enter code block mode
+            self.in_code_block = true;
+            self.buffer.push_str(chunk);
+            return None;
+        }
+
+        // Normal text - use existing logic
         self.buffer.push_str(chunk);
         let safe_end = self.find_safe_end();
 
         if safe_end > 0 {
-            // SAFETY: safe_end is always at a valid UTF-8 char boundary because:
-            // - We only set it after processing complete regex tokens (which match
-            //   valid UTF-8 sequences) or at newline positions (ASCII, single byte)
-            // - The regex tokenizer operates on &str which guarantees UTF-8
             let to_render = self.buffer[..safe_end].to_string();
             self.buffer = self.buffer[safe_end..].to_string();
             Some(truncate_code_blocks(&to_render))
@@ -343,6 +425,7 @@ impl MarkdownBuffer {
                 state.in_code_block = false;
                 state.code_fence_char = '\0';
                 state.code_fence_len = 0;
+                state.in_kroki_diagram = false;
 
                 if let Some(newline_pos) = line.find('\n') {
                     return Some(newline_pos + 1);
@@ -354,6 +437,14 @@ impl MarkdownBuffer {
             state.in_code_block = true;
             state.code_fence_char = fence_char;
             state.code_fence_len = fence_len;
+
+            // Check if this is a Kroki diagram block
+            if KROKI_DIAGRAM_TYPES
+                .iter()
+                .any(|&lang| after_fence.starts_with(lang))
+            {
+                state.in_kroki_diagram = true;
+            }
 
             if let Some(newline_pos) = line.find('\n') {
                 return Some(newline_pos + 1);

--- a/crates/leaf-cli/src/sixel/mod.rs
+++ b/crates/leaf-cli/src/sixel/mod.rs
@@ -1,0 +1,121 @@
+//! Direct Sixel rendering for SVG diagrams.
+//!
+//! This module provides pure Rust Sixel image rendering without external dependencies.
+
+use image::{ImageBuffer, Rgba};
+
+/// Renders an RGBA image buffer as Sixel format.
+pub fn encode_sixel(image: &ImageBuffer<Rgba<u8>, Vec<u8>>) -> String {
+    let (img_width, img_height) = image.dimensions();
+    let mut output = String::new();
+
+    // Sixel header: DECSIXEL
+    output.push_str("\x1bP0;1;0q");
+
+    // Define palette: color 1 = white, color 2 = black
+    // Format: #palette;2;R;G;B (2 = SGR mode)
+    output.push_str("#1;2;255;255;255"); // White
+    output.push_str("#2;2;0;0;0"); // Black
+
+    // Raster attributes: ;pan;pads;height;width
+    output.push_str(&format!(";1;1;{};{}", img_height, img_width));
+
+    // Select color 2 (black foreground)
+    output.push_str("#2");
+
+    let band_height = 6;
+    let bands = (img_height + band_height - 1) / band_height;
+
+    for band_y in 0..bands {
+        let y_start = band_y * band_height;
+        let y_end = std::cmp::min(y_start + band_height, img_height);
+        let actual_height = (y_end - y_start) as usize;
+
+        // Encode each column
+        for x in 0..img_width {
+            let mut sixel_bits: u8 = 0;
+            for (row_idx, y) in (y_start..y_end).enumerate() {
+                let luma = luminance(image.get_pixel(x, y));
+                // If pixel is dark (foreground), set corresponding bit
+                if luma < 128 {
+                    sixel_bits |= 1 << (actual_height - 1 - row_idx);
+                }
+            }
+            if sixel_bits != 0 {
+                if let Some(c) = char::from_u32(sixel_bits as u32 + 63) {
+                    output.push(c);
+                }
+            }
+        }
+
+        // End band
+        output.push('"');
+    }
+
+    // End Sixel (DECOSC)
+    output.push_str("\x1b\\");
+
+    output
+}
+
+/// Calculates luminance for a pixel (0-255 range).
+fn luminance(pixel: &Rgba<u8>) -> u8 {
+    let r = pixel[0] as f32;
+    let g = pixel[1] as f32;
+    let b = pixel[2] as f32;
+
+    // ITU-R BT.709 luminance coefficients
+    let luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    luma as u8
+}
+
+/// Renders SVG string to Sixel output.
+pub fn render_svg_to_sixel(svg: &str, width: u32, height: u32) -> Result<String, String> {
+    // Parse SVG using resvg
+    let opt = resvg::usvg::Options::default();
+    let tree = resvg::usvg::Tree::from_str(svg, &opt)
+        .map_err(|e| format!("Failed to parse SVG: {}", e))?;
+
+    // Create pixel buffer
+    let mut pixmap = resvg::tiny_skia::Pixmap::new(width, height)
+        .ok_or_else(|| "Failed to create pixmap".to_string())?;
+
+    // Render SVG to pixmap
+    let scale_x = width as f32 / tree.size().width();
+    let scale_y = height as f32 / tree.size().height();
+    let transform = resvg::tiny_skia::Transform::from_scale(scale_x, scale_y);
+
+    resvg::render(&tree, transform, &mut pixmap.as_mut());
+
+    // Convert to image buffer
+    let img: ImageBuffer<Rgba<u8>, Vec<u8>> =
+        ImageBuffer::from_raw(width, height, pixmap.take()).unwrap();
+
+    // Encode as Sixel
+    Ok(encode_sixel(&img))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sixel_header() {
+        let img: ImageBuffer<Rgba<u8>, Vec<u8>> = ImageBuffer::new(10, 10);
+        let sixel = encode_sixel(&img);
+        assert!(sixel.starts_with("\x1bP0;1;0q"));
+        assert!(sixel.ends_with("\x1b\\"));
+    }
+
+    #[test]
+    fn test_render_svg_simple() {
+        let svg = r#"<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+            <rect x="10" y="10" width="80" height="80" fill="red"/>
+        </svg>"#;
+
+        let result = render_svg_to_sixel(svg, 100, 100);
+        assert!(result.is_ok());
+        let sixel = result.unwrap();
+        assert!(sixel.starts_with("\x1bP0;1;0q"));
+    }
+}


### PR DESCRIPTION
## Summary

Renders diagram code blocks (mermaid, plantuml, dot, d2, etc.) as ASCII art in the terminal using [Kroki](https://kroki.io) text output format.

## Privacy-First Design

- **Disabled by default** — no data sent anywhere unless user explicitly configures it
- Set `LEAF_KROKI_URL=https://kroki.io` to enable (or use a self-hosted Kroki instance)
- If not configured, diagrams display as raw text (current behavior)

## How It Works

```
LLM outputs:     ```mermaid\ngraph TD; A-->B\n```
                        ↓ (extract_diagram_block)
Base64-encode:    Z3JhcGggVEQ7IEEtLT5C
                        ↓ (HTTP GET)
Kroki API:        GET https://kroki.io/mermaid/txt/Z3JhcGggVEQ7IEEtLT5C
                        ↓
ASCII art:       ┌───┐   ┌───┐
                  │ A │──▶│ B │
                  └───┘   └───┘
```

## Supported Diagram Types (25+)

mermaid, plantuml, dot, graphviz, d2, excalidraw, bytefield, wavedrom, nomnoml, pikchr, structurizr, vega, vegalite, erd, svgbob, umlet, wireviz, blockdiag, seqdiag, actdiag, nwdiag, packetdiag, rackdiag, c4plantuml

## Changes

- `crates/leaf-cli/src/session/output.rs`: Add `extract_diagram_block()`, `print_diagram()`, `KROKI_DIAGRAM_TYPES`, `get_kroki_url()`
- Diagram extraction follows same recursive pattern as existing table extraction (handles multiple diagrams)
- Graceful fallback to raw text on network errors
- Fix pre-existing clippy warning in `logging.rs`

## Configuration

```bash
# Enable with public Kroki
export LEAF_KROKI_URL=https://kroki.io

# Enable with self-hosted Kroki (privacy)
export LEAF_KROKI_URL=http://localhost:8000

# Disable (default)
# Simply do not set LEAF_KROKI_URL
```

Closes: #33