### PR TITLE
feat: improve welcome banner and input prompt

### DIFF
--- a/crates/leaf-cli/src/session/builder.rs
+++ b/crates/leaf-cli/src/session/builder.rs
@@ -716,11 +716,21 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
     configure_session_prompts(&session, config, &session_config, &session_id).await;
 
     if !session_config.quiet {
+        let message_count = if session_config.resume {
+            session_manager
+                .get_session(&session_id, false)
+                .await
+                .ok()
+                .map(|s| s.message_count)
+        } else {
+            None
+        };
         output::display_session_info(
             session_config.resume,
             &resolved.provider_name,
             &resolved.model_name,
             &Some(session_id),
+            message_count,
         );
     }
     session

--- a/crates/leaf-cli/src/session/input.rs
+++ b/crates/leaf-cli/src/session/input.rs
@@ -1,6 +1,7 @@
 use super::completion::LeafCompleter;
 use super::{CompletionCache, HintStatus};
 use anyhow::Result;
+use console::style;
 use leaf::config::{Config, LeafMode};
 use rustyline::Editor;
 use shlex;
@@ -462,7 +463,7 @@ fn parse_model_command(input: &str) -> Option<InputResult> {
 }
 
 fn get_input_prompt_string() -> String {
-    "🌿 ".to_string()
+    format!("{} ", style("❯").green())
 }
 
 fn print_help() {

--- a/crates/leaf-cli/src/session/output.rs
+++ b/crates/leaf-cli/src/session/output.rs
@@ -1305,6 +1305,7 @@ pub fn display_session_info(
     provider: &str,
     model: &str,
     session_id: &Option<String>,
+    message_count: Option<usize>,
 ) {
     set_terminal_title();
 
@@ -1320,33 +1321,73 @@ pub fn display_session_info(
 
     let cwd_display = std::env::current_dir()
         .ok()
-        .map(|p| p.display().to_string())
+        .map(|p| shorten_path(&p.display().to_string(), false))
         .unwrap_or_else(|| "unknown".to_string());
 
-    // ASCII art leaf with session info on the right
-    println!(
-        "  {} {} {} {}",
+    let line1 = format!(
+        " {} {} {} {}",
         style(status).dim(),
         style("·").dim(),
         style(provider).dim(),
         style(&model_display).cyan(),
     );
+    let line1_plain = format!(" {} · {} {}", status, provider, &model_display);
 
-    if let Some(id) = session_id {
-        println!(
-            "  {} {} {}",
-            style(" ").dim(),
-            style(id).dim(),
-            style(format!("· {}", cwd_display)).dim(),
-        );
+    let line2 = if let Some(id) = session_id {
+        let msg_info = match message_count {
+            Some(count) if count > 0 => format!(" · {} messages", count),
+            _ => String::new(),
+        };
+        let cwd_part = format!("· {}", cwd_display);
+        (
+            format!(
+                " {}{}{}",
+                style(id).dim(),
+                style(&cwd_part).dim(),
+                style(&msg_info).dim(),
+            ),
+            format!(" {}{}{}", id, cwd_part, msg_info),
+        )
     } else {
-        println!(
-            "  {} {}",
-            style(" ").dim(),
-            style(format!("  {}", cwd_display)).dim(),
-        );
-    }
-    println!("  {}", style("   leaf is ready").white());
+        (
+            format!(" {}", style(&cwd_display).dim()),
+            format!(" {}", cwd_display),
+        )
+    };
+
+    let inner_width = line1_plain.len().max(line2.1.len());
+    let box_width = inner_width;
+
+    println!(
+        "{}",
+        style(format!("╭{}╮", "─".repeat(box_width)))
+            .fg(Color::Green)
+            .dim()
+    );
+    println!(
+        "{}{}{}",
+        style("│").fg(Color::Green).dim(),
+        pad_to_width(&line1, &line1_plain, inner_width),
+        style("│").fg(Color::Green).dim()
+    );
+    println!(
+        "{}{}{}",
+        style("│").fg(Color::Green).dim(),
+        pad_to_width(&line2.0, &line2.1, inner_width),
+        style("│").fg(Color::Green).dim()
+    );
+    println!(
+        "{}",
+        style(format!("╰{}╯", "─".repeat(box_width)))
+            .fg(Color::Green)
+            .dim()
+    );
+}
+
+fn pad_to_width(styled_line: &str, plain_line: &str, target_width: usize) -> String {
+    let current_width = measure_text_width(plain_line);
+    let padding = target_width.saturating_sub(current_width);
+    format!("{}{}", styled_line, " ".repeat(padding))
 }
 
 fn set_terminal_title() {


### PR DESCRIPTION
## Summary

Closes #35

### Feature 1: Welcome Banner

Replace the flat banner with a rounded box:

```
╭─────────────────────────────────────────────────────────────────────────╮
│  resuming · opencode-zhipuai-coding-plan-openai-compatible glm-5.1     │
│  20260329_2 · ~/src/oss/leaf · 12 messages                             │
╰─────────────────────────────────────────────────────────────────────────╯
  ━━━━━━━━╌╌╌╌╌╌╌╌╌╌╌╌ 38% 49k/128k
```

- Rounded box with right-side closure, auto-width to longest content line
- `~/` path shorthand via existing `shorten_path`
- Message count on second line (resumed sessions only)
- Drop "leaf is ready"
- Keep color scheme: dim status + `·`, cyan model

### Feature 2: Input Prompt

Change `🌿 ` → green `❯ `

Terminal-native, consistent with existing `▸` tool indicator, avoids emoji rendering issues across terminals/fonts.

### Files changed

- `crates/leaf-cli/src/session/output.rs` — rewrite `display_session_info` with box rendering
- `crates/leaf-cli/src/session/builder.rs` — pass message count to banner
- `crates/leaf-cli/src/session/input.rs` — green `❯` prompt

### Verification

- `cargo check -p leaf-cli` ✅
- `cargo fmt` ✅
- `cargo clippy -p leaf-cli --all-targets -- -D warnings` ✅ (no new warnings; pre-existing `logging.rs` issue unrelated)
- `cargo test -p leaf-cli --lib` ✅ (163 passed)