### PR TITLE
Upstream sync: adopt 5 commits from block/goose (582582159..bc296816b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,30 @@ jobs:
           RUST_MIN_STACK: 8388608
 
 
+  rust-build-windows:
+    name: Build Rust Project on Windows
+    runs-on: windows-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: windows-ci
+
+      - name: Setup Rust
+        shell: bash
+        run: |
+          rustup show
+          rustup target add x86_64-pc-windows-msvc
+
+      - name: Build
+        run: cargo build --target x86_64-pc-windows-msvc
+        env:
+          CARGO_INCREMENTAL: "0"
+
   rust-lint:
     name: Lint Rust Code
     runs-on: ubuntu-latest

--- a/crates/leaf/src/providers/codex_acp.rs
+++ b/crates/leaf/src/providers/codex_acp.rs
@@ -14,6 +14,7 @@ use crate::model::ModelConfig;
 use crate::providers::base::{ProviderDef, ProviderMetadata};
 
 const CODEX_ACP_PROVIDER_NAME: &str = "codex-acp";
+pub const CODEX_ACP_DEFAULT_MODEL: &str = "current";
 const CODEX_ACP_DOC_URL: &str = "https://github.com/zed-industries/codex-acp";
 const CODEX_ACP_BINARY: &str = "codex";
 

--- a/crates/leaf/src/providers/copilot_acp.rs
+++ b/crates/leaf/src/providers/copilot_acp.rs
@@ -12,30 +12,33 @@ use crate::config::{Config, LeafMode};
 use crate::model::ModelConfig;
 use crate::providers::base::{ProviderDef, ProviderMetadata};
 
-const CLAUDE_ACP_PROVIDER_NAME: &str = "claude-acp";
-pub const CLAUDE_ACP_DEFAULT_MODEL: &str = "current";
-const CLAUDE_ACP_DOC_URL: &str = "https://github.com/zed-industries/claude-agent-acp";
-const CLAUDE_ACP_BINARY: &str = "claude-agent-acp";
+const COPILOT_ACP_PROVIDER_NAME: &str = "copilot-acp";
+pub const COPILOT_ACP_DEFAULT_MODEL: &str = "current";
+const COPILOT_ACP_DOC_URL: &str = "https://github.com/github/copilot-cli";
+const COPILOT_ACP_BINARY: &str = "copilot";
 
-pub struct ClaudeAcpProvider;
+const MODE_AGENT: &str = "https://agentclientprotocol.com/protocol/session-modes#agent";
+const MODE_PLAN: &str = "https://agentclientprotocol.com/protocol/session-modes#plan";
 
-impl ProviderDef for ClaudeAcpProvider {
+pub struct CopilotAcpProvider;
+
+impl ProviderDef for CopilotAcpProvider {
     type Provider = AcpProvider;
 
     fn metadata() -> ProviderMetadata {
         ProviderMetadata::new(
-            CLAUDE_ACP_PROVIDER_NAME,
-            "Claude Code",
-            "Use leaf with your Claude Code subscription via the claude-agent-acp adapter.",
+            COPILOT_ACP_PROVIDER_NAME,
+            "GitHub Copilot CLI (ACP)",
+            "Use leaf with your GitHub Copilot subscription via the Copilot CLI.",
             ACP_CURRENT_MODEL,
             vec![],
-            CLAUDE_ACP_DOC_URL,
+            COPILOT_ACP_DOC_URL,
             vec![],
         )
         .with_setup_steps(vec![
-            "Install the ACP adapter: `npm install -g @zed-industries/claude-agent-acp`",
-            "Ensure your Claude CLI is authenticated (run `claude` to verify)",
-            "Set in your leaf config file (`~/.config/leaf/config.yaml` on macOS/Linux):\n  LEAF_PROVIDER: claude-acp\n  LEAF_MODEL: current",
+            "Install the Copilot CLI: `npm install -g @github/copilot`",
+            "Run `copilot login` to authenticate with your GitHub account",
+            "Set in your leaf config file (`~/.config/leaf/config.yaml` on macOS/Linux):\n  LEAF_PROVIDER: copilot-acp\n  LEAF_MODEL: current",
             "Restart leaf for changes to take effect",
         ])
     }
@@ -48,27 +51,29 @@ impl ProviderDef for ClaudeAcpProvider {
             let config = Config::global();
             let resolved_command = SearchPaths::builder()
                 .with_npm()
-                .resolve(CLAUDE_ACP_BINARY)?;
+                .resolve(COPILOT_ACP_BINARY)?;
             let leaf_mode = config.get_leaf_mode().unwrap_or(LeafMode::Auto);
 
-            let permission_mapping = PermissionMapping {
-                allow_option_id: Some("allow".to_string()),
-                reject_option_id: Some("reject".to_string()),
-                rejected_tool_status: sacp::schema::ToolCallStatus::Failed,
-            };
+            let permission_mapping = PermissionMapping::default();
+
+            let mut args = vec!["--acp".to_string()];
+            if model.model_name != COPILOT_ACP_DEFAULT_MODEL {
+                args.push("--model".to_string());
+                args.push(model.model_name.clone());
+            }
 
             let mode_mapping = HashMap::from([
-                (LeafMode::Auto, "bypassPermissions".to_string()),
-                (LeafMode::Approve, "default".to_string()),
-                (LeafMode::SmartApprove, "acceptEdits".to_string()),
-                (LeafMode::Chat, "plan".to_string()),
+                (LeafMode::Auto, MODE_AGENT.to_string()),
+                (LeafMode::Approve, MODE_AGENT.to_string()),
+                (LeafMode::SmartApprove, MODE_AGENT.to_string()),
+                (LeafMode::Chat, MODE_PLAN.to_string()),
             ]);
 
             let provider_config = AcpProviderConfig {
                 command: resolved_command,
-                args: vec![],
+                args,
                 env: vec![],
-                env_remove: vec!["CLAUDECODE".to_string()],
+                env_remove: vec![],
                 work_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
                 session_mode_id: Some(mode_mapping[&leaf_mode].clone()),

--- a/crates/leaf/src/providers/formats/mod.rs
+++ b/crates/leaf/src/providers/formats/mod.rs
@@ -1,5 +1,6 @@
 pub mod anthropic;
 pub mod databricks;
+pub mod gcpvertexai;
 pub mod google;
 pub mod ollama;
 pub mod openai;

--- a/crates/leaf/src/providers/formats/openai.rs
+++ b/crates/leaf/src/providers/formats/openai.rs
@@ -750,7 +750,7 @@ where
                         let parsed = if arguments.is_empty() {
                             Ok(json!({}))
                         } else {
-                            serde_json::from_str::<Value>(arguments)
+                            safely_parse_json(arguments)
                         };
 
                         let metadata = if let Some(sig) = &last_signature {

--- a/crates/leaf/src/providers/gcpauth.rs
+++ b/crates/leaf/src/providers/gcpauth.rs
@@ -1,0 +1,1115 @@
+use async_trait::async_trait;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::{env, fmt, io};
+use tokio::sync::RwLock;
+
+/// Represents errors that can occur during GCP authentication.
+///
+/// This enum encompasses various error conditions that might arise during
+/// the authentication process, including credential loading, token creation,
+/// and token exchange operations.
+#[derive(Debug, thiserror::Error)]
+pub enum AuthError {
+    /// Error when loading credentials from the filesystem or environment
+    #[error("Failed to load credentials: {0}")]
+    Credentials(String),
+
+    /// Error during JWT token creation
+    #[error("Token creation failed: {0}")]
+    TokenCreation(String),
+
+    /// Error during OAuth token exchange
+    #[error("Token exchange failed: {0}")]
+    TokenExchange(String),
+}
+
+/// Represents an authentication token with its type and value.
+///
+/// This structure holds both the token type (e.g., "Bearer") and its
+/// actual value, typically used for authentication with GCP services.
+/// The token is obtained either through service account or user credentials.
+#[derive(Debug, Clone)]
+pub struct AuthToken {
+    /// The type of the token (e.g., "Bearer")
+    pub token_type: String,
+    /// The actual token value
+    pub token_value: String,
+}
+
+impl fmt::Display for AuthToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {}", self.token_type, self.token_value)
+    }
+}
+
+/// Represents the types of Application Default Credentials (ADC) supported.
+///
+/// GCP supports multiple credential types for authentication. This enum
+/// represents the two main types: authorized user and service account.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AdcCredentials {
+    /// Credentials for an authorized user (typically from gcloud auth)
+    AuthorizedUser(AuthorizedUserCredentials),
+    /// Credentials for a service account
+    ServiceAccount(ServiceAccountCredentials),
+    /// Credentials for the GCP native default account
+    DefaultAccount(TokenResponse),
+}
+
+/// Credentials for an authorized user account.
+///
+/// These credentials are typically obtained through interactive login
+/// with the gcloud CLI tool.
+#[derive(Debug, Deserialize)]
+struct AuthorizedUserCredentials {
+    /// OAuth 2.0 client ID
+    client_id: String,
+    /// OAuth 2.0 client secret
+    client_secret: String,
+    /// OAuth 2.0 refresh token
+    refresh_token: String,
+    /// URI for token refresh requests
+    #[serde(default = "default_token_uri")]
+    token_uri: String,
+}
+
+/// Credentials for a service account.
+///
+/// These credentials are typically obtained from a JSON key file
+/// downloaded from the Google Cloud Console.
+#[derive(Debug, Deserialize)]
+struct ServiceAccountCredentials {
+    /// Service account email address
+    client_email: String,
+    /// The private key from JSON credential for signing JWT tokens
+    private_key: String,
+    /// URI for token exchange requests
+    token_uri: String,
+}
+
+/// Returns the default OAuth 2.0 token endpoint.
+fn default_token_uri() -> String {
+    "https://oauth2.googleapis.com/token".to_string()
+}
+
+/// A trait that defines operations for interacting with the filesystem.
+///
+/// This trait provides an abstraction over filesystem operations, primarily
+/// for reading credential files. It enables testing through mock implementations.
+#[async_trait]
+pub trait FilesystemOps {
+    /// Reads the contents of a file into a string.
+    ///
+    /// # Arguments
+    /// * `path` - The path to the file to read
+    ///
+    /// # Returns
+    /// * `Result<String, io::Error>` - The contents of the file or an error
+    async fn read_to_string(&self, path: String) -> Result<String, io::Error>;
+}
+
+/// A trait that defines operations for accessing environment variables.
+///
+/// This trait provides an abstraction over environment variable access,
+/// enabling testing through mock implementations.
+pub trait EnvOps {
+    /// Retrieves the value of an environment variable.
+    ///
+    /// # Arguments
+    /// * `key` - The name of the environment variable
+    ///
+    /// # Returns
+    /// * `Result<String, env::VarError>` - The value of the variable or an error if not found
+    fn get_var(&self, key: &str) -> Result<String, env::VarError>;
+}
+
+/// A concrete implementation of FilesystemOps using the actual filesystem.
+///
+/// This implementation uses tokio's async filesystem operations for
+/// reading files in an asynchronous manner.
+pub struct RealFilesystemOps;
+
+/// A concrete implementation of EnvOps using the actual environment.
+///
+/// This implementation directly accesses system environment variables
+/// through the standard library.
+pub struct RealEnvOps;
+
+#[async_trait]
+impl FilesystemOps for RealFilesystemOps {
+    async fn read_to_string(&self, path: String) -> Result<String, io::Error> {
+        tokio::fs::read_to_string(path).await
+    }
+}
+
+impl EnvOps for RealEnvOps {
+    fn get_var(&self, key: &str) -> Result<String, env::VarError> {
+        env::var(key)
+    }
+}
+
+impl AdcCredentials {
+    /// Loads credentials from the default locations.
+    /// https://cloud.google.com/docs/authentication/application-default-credentials#personal
+    ///
+    /// Attempts to load credentials in the following order:
+    /// 1. GOOGLE_APPLICATION_CREDENTIALS environment variable
+    /// 2. Default gcloud credentials path (~/.config/gcloud/application_default_credentials.json)
+    /// 3. Metadata server if running in GCP
+    async fn load() -> Result<Self, AuthError> {
+        Self::load_impl(
+            &RealFilesystemOps,
+            &RealEnvOps,
+            "http://metadata.google.internal",
+        )
+        .await
+    }
+
+    async fn load_impl(
+        fs_ops: &impl FilesystemOps,
+        env_ops: &impl EnvOps,
+        metadata_base_url: &str,
+    ) -> Result<Self, AuthError> {
+        // Try GOOGLE_APPLICATION_CREDENTIALS first
+        if let Ok(cred_path) = Self::get_env_credentials_path(env_ops) {
+            if let Ok(creds) = Self::load_from_file(fs_ops, &cred_path).await {
+                return Ok(creds);
+            }
+        }
+
+        // Try default gcloud credentials path
+        if let Ok(cred_path) = Self::get_default_credentials_path(env_ops) {
+            if let Ok(creds) = Self::load_from_file(fs_ops, &cred_path).await {
+                return Ok(creds);
+            }
+        }
+
+        // Try metadata server if running on GCP
+        if let Ok(creds) = Self::load_from_metadata_server(metadata_base_url).await {
+            return Ok(creds);
+        }
+
+        Err(AuthError::Credentials(
+            "No valid credentials found in any location".to_string(),
+        ))
+    }
+
+    async fn load_from_file(fs_ops: &impl FilesystemOps, path: &str) -> Result<Self, AuthError> {
+        let content = fs_ops.read_to_string(path.to_string()).await.map_err(|e| {
+            AuthError::Credentials(format!("Failed to read credentials from {}: {}", path, e))
+        })?;
+
+        serde_json::from_str(&content)
+            .map_err(|e| AuthError::Credentials(format!("Invalid credentials format: {}", e)))
+    }
+
+    fn get_env_credentials_path(env_ops: &impl EnvOps) -> Result<String, AuthError> {
+        env_ops
+            .get_var("GOOGLE_APPLICATION_CREDENTIALS")
+            .map_err(|_| {
+                AuthError::Credentials("GOOGLE_APPLICATION_CREDENTIALS not set".to_string())
+            })
+    }
+
+    fn get_default_credentials_path(env_ops: &impl EnvOps) -> Result<String, AuthError> {
+        let (env_var, subpath) = if cfg!(windows) {
+            ("APPDATA", "gcloud\\application_default_credentials.json")
+        } else {
+            (
+                "HOME",
+                ".config/gcloud/application_default_credentials.json",
+            )
+        };
+
+        env_ops
+            .get_var(env_var)
+            .map(|dir| {
+                PathBuf::from(dir)
+                    .join(subpath)
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .map_err(|_| {
+                AuthError::Credentials("Could not determine user home directory".to_string())
+            })
+    }
+
+    async fn load_from_metadata_server(base_url: &str) -> Result<Self, AuthError> {
+        let client = reqwest::Client::new();
+        let metadata_path = "/computeMetadata/v1/instance/service-accounts/default/token";
+
+        let response = client
+            .get(format!("{}{}", base_url, metadata_path))
+            .header("Metadata-Flavor", "Google")
+            .send()
+            .await
+            .map_err(|e| {
+                AuthError::Credentials(format!("Metadata server request failed: {}", e))
+            })?;
+
+        if !response.status().is_success() {
+            return Err(AuthError::Credentials(
+                "Not running on GCP or metadata server unavailable".to_string(),
+            ));
+        }
+
+        // Get the identity token and credentials from metadata server
+        let token_response = response
+            .json::<TokenResponse>()
+            .await
+            .map_err(|e| AuthError::Credentials(format!("Invalid metadata response: {}", e)))?;
+
+        // Note: When using metadata server, we have access to the OAuth2 access token
+        // that can be used to authenticate applications.
+        Ok(AdcCredentials::DefaultAccount(TokenResponse {
+            token_type: token_response.token_type,
+            access_token: token_response.access_token,
+            expires_in: token_response.expires_in,
+        }))
+    }
+}
+
+/// Claims structure for JWT tokens.
+///
+/// These claims are included in the JWT token used for service account
+/// authentication.
+#[derive(Debug, Serialize)]
+struct JwtClaims {
+    /// Token issuer (service account email)
+    iss: String,
+    /// Token subject (service account email)
+    sub: String,
+    /// Service account scope within role
+    scope: String,
+    /// Token audience (OAuth endpoint)
+    aud: String,
+    /// Token issued at timestamp
+    iat: u64,
+    /// Token expiration timestamp
+    exp: u64,
+}
+
+/// Holds a cached token and its expiration time.
+///
+/// Used internally to implement token caching and automatic refresh.
+#[derive(Debug, Clone)]
+struct CachedToken {
+    /// The cached authentication token
+    token: AuthToken,
+    /// When the token will expire
+    expires_at: Instant,
+}
+
+/// Response structure for token exchange requests.
+#[derive(Debug, Deserialize, Clone)]
+struct TokenResponse {
+    /// The access token string
+    access_token: String,
+    /// Token lifetime in seconds
+    expires_in: u64,
+    /// Token type (e.g., "Bearer")
+    #[serde(default)]
+    token_type: String,
+}
+
+/// Handles authentication with Google Cloud Platform services.
+///
+/// This struct manages the complete authentication lifecycle including:
+/// - Loading and validating credentials
+/// - Creating and refreshing tokens
+/// - Caching tokens for efficient reuse
+/// - Managing concurrent access through atomic operations
+///
+/// It supports both service account and authorized user authentication methods,
+/// automatically selecting the appropriate method based on available credentials.
+/// ```
+#[derive(Debug)]
+pub struct GcpAuth {
+    /// The loaded credentials (service account or authorized user)
+    credentials: AdcCredentials,
+    /// HTTP client for making token exchange requests
+    client: reqwest::Client,
+    /// Thread-safe cache for the current token
+    cached_token: Arc<RwLock<Option<CachedToken>>>,
+}
+
+impl GcpAuth {
+    /// Creates a new GCP authentication handler.
+    ///
+    /// Initializes the authentication handler by:
+    /// 1. Loading credentials from default locations
+    /// 2. Setting up an HTTP client for token requests
+    /// 3. Initializing the token cache
+    ///
+    /// The credentials are loaded in the following order:
+    /// 1. GOOGLE_APPLICATION_CREDENTIALS environment variable
+    /// 2. Default gcloud credentials path
+    /// 3. GCP metadata server (when running on GCP)
+    ///
+    /// # Returns
+    /// * `Result<Self, AuthError>` - A new GcpAuth instance or an error if initialization fails
+    pub async fn new() -> Result<Self, AuthError> {
+        Ok(Self {
+            credentials: AdcCredentials::load().await?,
+            client: reqwest::Client::new(),
+            cached_token: Arc::new(RwLock::new(None)),
+        })
+    }
+
+    /// Retrieves a valid authentication token.
+    ///
+    /// This method implements an efficient token management strategy:
+    /// 1. Checks the cache for a valid token
+    /// 2. Returns the cached token if not expired
+    /// 3. Obtains a new token if needed or expired
+    /// 4. Uses double-checked locking for thread safety
+    ///
+    /// The returned token includes a type (usually "Bearer") and the actual
+    /// token value used for authentication with GCP services.
+    ///
+    /// # Returns
+    /// * `Result<AuthToken, AuthError>` - A valid authentication token or an error
+    pub async fn get_token(&self) -> Result<AuthToken, AuthError> {
+        // Try read lock first for better concurrency
+        if let Some(cached) = self.cached_token.read().await.as_ref() {
+            if cached.expires_at > Instant::now() {
+                return Ok(cached.token.clone());
+            }
+        }
+
+        // Take write lock only if needed
+        let mut token_guard = self.cached_token.write().await;
+
+        // Double-check expiration after acquiring write lock
+        if let Some(cached) = token_guard.as_ref() {
+            if cached.expires_at > Instant::now() {
+                return Ok(cached.token.clone());
+            }
+        }
+
+        // Get new token
+        let token_response = match &self.credentials {
+            AdcCredentials::ServiceAccount(creds) => self.get_service_account_token(creds).await?,
+            AdcCredentials::AuthorizedUser(creds) => self.get_authorized_user_token(creds).await?,
+            AdcCredentials::DefaultAccount(creds) => self.get_default_access_token(creds).await?,
+        };
+
+        let auth_token = AuthToken {
+            token_type: if token_response.token_type.is_empty() {
+                "Bearer".to_string()
+            } else {
+                token_response.token_type
+            },
+            token_value: token_response.access_token,
+        };
+
+        let expires_at = Instant::now()
+            + Duration::from_secs(
+                token_response.expires_in.saturating_sub(30), // 30 second buffer
+            );
+
+        *token_guard = Some(CachedToken {
+            token: auth_token.clone(),
+            expires_at,
+        });
+
+        Ok(auth_token)
+    }
+
+    /// Creates a JWT token for service account authentication.
+    ///
+    /// # Arguments
+    /// * `creds` - Service account credentials for signing the token
+    ///
+    /// # Returns
+    /// * `Result<String>` - A signed JWT token
+    fn create_jwt_token(&self, creds: &ServiceAccountCredentials) -> Result<String, AuthError> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| AuthError::TokenCreation(e.to_string()))?
+            .as_secs();
+
+        let claims = JwtClaims {
+            iss: creds.client_email.clone(),
+            sub: creds.client_email.clone(),
+            scope: "https://www.googleapis.com/auth/cloud-platform".to_string(),
+            aud: creds.token_uri.clone(),
+            iat: now,
+            exp: now + 3600, // 1 hours validity
+        };
+
+        let encoding_key = EncodingKey::from_rsa_pem(creds.private_key.as_bytes())
+            .map_err(|e| AuthError::TokenCreation(format!("Invalid private key: {}", e)))?;
+
+        encode(
+            &Header::new(jsonwebtoken::Algorithm::RS256),
+            &claims,
+            &encoding_key,
+        )
+        .map_err(|e| AuthError::TokenCreation(format!("Failed to create JWT: {}", e)))
+    }
+
+    /// Exchanges a token or assertion for an access token.
+    ///
+    /// # Arguments
+    /// * `token_uri` - The token exchange endpoint
+    /// * `params` - Parameters for the token exchange request
+    ///
+    /// # Returns
+    /// * `Result<TokenResponse>` - The token exchange response
+    async fn exchange_token(
+        &self,
+        token_uri: &str,
+        params: &[(&str, &str)],
+    ) -> Result<TokenResponse, AuthError> {
+        let response = self
+            .client
+            .post(token_uri)
+            .form(params)
+            .send()
+            .await
+            .map_err(|e| AuthError::TokenExchange(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(AuthError::TokenExchange(format!(
+                "Status {}: {}",
+                status, error_text
+            )));
+        }
+
+        response
+            .json::<TokenResponse>()
+            .await
+            .map_err(|e| AuthError::TokenExchange(format!("Invalid response: {}", e)))
+    }
+
+    /// Gets a token using service account credentials.
+    ///
+    /// # Arguments
+    /// * `creds` - Service account credentials
+    ///
+    /// # Returns
+    /// * `Result<TokenResponse>` - The token response
+    async fn get_service_account_token(
+        &self,
+        creds: &ServiceAccountCredentials,
+    ) -> Result<TokenResponse, AuthError> {
+        let jwt = self.create_jwt_token(creds)?;
+        let params = [
+            ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+            ("assertion", &jwt),
+            ("scope", "https://www.googleapis.com/auth/cloud-platform"),
+        ];
+
+        self.exchange_token(&creds.token_uri, &params).await
+    }
+
+    /// Gets a token using authorized user credentials.
+    ///
+    /// # Arguments
+    /// * `creds` - Authorized user credentials
+    ///
+    /// # Returns
+    /// * `Result<TokenResponse>` - The token response
+    async fn get_authorized_user_token(
+        &self,
+        creds: &AuthorizedUserCredentials,
+    ) -> Result<TokenResponse, AuthError> {
+        let params = [
+            ("client_id", creds.client_id.as_str()),
+            ("client_secret", creds.client_secret.as_str()),
+            ("refresh_token", creds.refresh_token.as_str()),
+            ("grant_type", "refresh_token"),
+            ("scope", "https://www.googleapis.com/auth/cloud-platform"),
+        ];
+
+        self.exchange_token(&creds.token_uri, &params).await
+    }
+
+    /// Gets a token directly from the GCP metadata endpoint.
+    ///
+    /// # Arguments
+    /// * `creds` - Default Access Token Response
+    ///
+    /// # Returns
+    /// * `Result<TokenResponse>` - The token response
+    async fn get_default_access_token(
+        &self,
+        creds: &TokenResponse,
+    ) -> Result<TokenResponse, AuthError> {
+        Ok(creds.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockall::predicate::eq;
+    use tokio::time::sleep;
+    use wiremock::matchers::{header, method, path};
+    // Only import what we need
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    mockall::mock! {
+        #[derive(Debug)]
+        FilesystemOpsMock {}
+
+        #[async_trait]
+        impl FilesystemOps for FilesystemOpsMock {
+            async fn read_to_string(&self, path: String) -> Result<String, std::io::Error>;
+        }
+    }
+
+    mockall::mock! {
+        #[derive(Debug)]
+        EnvOpsMock {}
+
+        impl EnvOps for EnvOpsMock {
+            fn get_var(&self, key: &str) -> Result<String, env::VarError>;
+        }
+    }
+
+    struct TestContext {
+        fs_mock: MockFilesystemOpsMock,
+        env_mock: MockEnvOpsMock,
+        mock_server: Option<MockServer>,
+    }
+
+    impl TestContext {
+        fn new() -> Self {
+            Self {
+                fs_mock: MockFilesystemOpsMock::new(),
+                env_mock: MockEnvOpsMock::new(),
+                mock_server: None,
+            }
+        }
+
+        async fn with_metadata_server(mut self) -> Self {
+            self.mock_server = Some(MockServer::start().await);
+            self
+        }
+    }
+
+    // Test fixtures for credentials
+    fn mock_service_account() -> ServiceAccountCredentials {
+        ServiceAccountCredentials {
+            client_email: "test@test.com".to_string(),
+            // This is a generated test credential
+            private_key: "-----BEGIN RSA PRIVATE KEY-----
+MIIJJwIBAAKCAgEA1AjOgxm0Op/DDVhMK1ifZatszNsKvuFSK12uuJ5oWkOIO+kt
+GW/bgN3E+naX9Zsq6yeVG+uJsw9XQbLGKvHAV+H1QIarIGQCsyLUTX06AUdf9Hg7
+bhMK2u6LQm2vnyF+pNu9Xu9zRRS7BIVrtn3ECNIpj+AuTXuZvI2bsfu6W2c54tIa
+KuDY68zonesmyfukbMpXiTOPWk6il7Uuj51EcgjDOT1y1fgA6UEIcUb3znq8pqQf
+ebnF22rgGH4zFHkJa2j1cCVmJcCyBi74phdupeF80Y6NxNrxcehQzSePrb6PoDwa
+VeA7I+9Voi8gCCExztydi1rhMgELvBDbWySLgKPLy3I7apHP6M2FOh8aYUoojX7+
+h7wD+ecMYLUxeZaTtgCKj4igAO14c1c6OVR5UWUlbGFTVxRCZ/+5JsfSzO6DRpql
+YcJudtqg1hqAvHEmneSA+/mtFKfRYd86jgHlHFZVIdCdo5CFRBMniYJiJj8/MIKW
+TQsmjxLTNTQfsJ92X2sMizJWvlg6d+oP6biYWEhKvkuiKG60PYf/17IMddk16pkM
+aYWfVIuDxYzduXDmaX03NV8TfeZIXA9C3SdINePju8U0V3ElK6ipQ6zcb/wSFCcj
+v1MmDZ8M7t2F8uhQk+k38BRco9tDlsgZ/yC8n9XZDGi7gUgd0IbRVRPUDt0CAwEA
+AQKCAgBRWW+h7OKw+0qifBX9K2s8XqDHl+JviZM1ACRgwKXYu8Aw/C1JbRkSQAOq
+9IUovfehcPZMV/nksSYRFr3hDA93qEGoGALf0n8Wq244rKrsgq3V5asneDbZ+FuF
+iP+wVfF43rWxDr1y65k1CttgkK/9kmRPxvr8z0cUiGAL0UCWgOw8kc9oVAvlrCAz
+Nl0TcXCMLLWY9icxxqmq+uB6SSRRe/sqouDEJvpyg3jxvQCmP4DRjnZlBVlb7Y08
+2G5QlH+Ariw8cpzWLzAeHzdWwfa5veFdpQvPUxD/WtplW6BMUKhaGbUg7X7DMrfw
+GZR4igPKEep/5MYxoSUXaoA+X68FYP753HHnQl10r6NsDymAmsAmWMxwUb/Ip6u/
+n19DI8ZXMdgb7aNwDAFdTOYmRVR+UVmJBMKyFKkVDsmqZabYB0yTECHh7Apunro/
+oJEK4E8JHjtLt/+7hhytZNS7e2Je1fw8DeRLoa6cMBraJS3CKEKaabgwmc0yY5ME
+fRvt9kqn8XnJON4zV+I80d9S77ihcTr8xlFI+9PAutlmYe5ZgTls4fKpcl8WWxsU
+kuQzL+u5I7TBvGZ3XL2uZKc2CPYLho8MGHbh4t5qF3zwjLFWZoQSPywBo7cN0kMP
+e5NhjEOY81LvPHTuAup8hnJ8JjR2qHTD7/qZ7e1tOrH7IrhyIQKCAQEA7pqIhffw
+O95e/ZshBLynFXVgvTEBzvnsBm7q9ItR2ytcGb15yJl+JNtv3Jcg5uMmfmd2tXxr
+68MaJ5/V2j2PQGLcPVlIhCW0b9NH8/c2NA15o78QClbh4x0eqz4qCfwmGsktPC6Q
+YUVaFKng+ECTWwjFTApKFUZFE/Jrg2N8RdMjYFIvLEMal8Co1AIn62eHPwC8xlW7
+69F+80KvxxEVmkDxEhG1p/BMQ+dimWdrtxyB+20LWK1N7zpg/Cmzo50gyLxvvJ6W
+ekXdJpG1LcwVZxqvUK1NMvbxpLFFUY4ZCmotlw9M8i/3W+Hfs4HSqKI3lUOYDYQd
+8xRQw6N8BSOHFwKCAQEA435dxFB46FgYN8NfCv8qUgO38maO0pETQjrUh5A4J3pS
+UyNIWqAmlkMo9tCDQZMyvhl8fV/uQoeDW9FiCijaffE7POkyRRTt+0mz/xuxjoeT
+Dc5IREE6xcLOd/nH6EsWZu3B0HWoLcK+63Dt2psGFUdqMRAuwr9XGfI3uqr8slTQ
+uqTpEc+/i80/hyWSu4+dDTwt+sU4+3dYiY719GHOXy5/j54jz0LwjiH4G7Di5teT
+yAWRX9SD06dSHy1qgqY7LZ3cxtLmQEGmFtTEPL5h/tPKx/tyX3baEiH6MmyuS1FK
+o30TYQMb16taN4wC1ztDjJ/BCOJqVOF5fU1kNYFSKwKCAQB4CgDDPXB7/izV89SR
+uINqtUm9BMm/IlcPCYBlFS5SUCcewAdj12zyB//n/5RK9F5qW40KUxVMYDRpWO1S
+xYOrRdE9gAyOhxWW6LmbUHTRjTH0Imxkdz9fbkf+qOCnc1aMRUffriFu/mAKY0jO
+PFamBuyTi92nhFm+ZkiWqldcHZP/onkfEIdxbzjAqHEC6mvNU4alVX6cbiIrKhKa
+2MqAd0mQ6J32ZltIEkG1oaU8UzhFkJ+TtmSuBTXDxwscNjHHK54fS72yuDFBdS6s
+Yq8l1vP6Z6WeDUSWsaSJGi8Y4UAcblMsyNruO926Rob/1dSW4JG/wwb6Qu867aW4
+RB5zAoIBABsXyJkBsHSTUUcK2H3Zx7N+x+BxgF7pci64DOmcLmPdOIK4N/y7B/1r
+QCysxoT/v9JN/Lp9u0VnGCjONevZ07OeEBz/9MGvbWw46dve83VzBftl7staLWKy
+AZ7eO4WZs7BMboGiEYZppA0sJNedEMtl9uqi7763xOrNIv/zLycZ3MXtr+g0Iq7G
+oeM5gVEfGGgkG6G67T9dhkjTos0Y/NfvFLgI8GDVqwpyVzcNCOjPEcWHjDmqeIyz
+Z59Y7E9k9rVHEK0JHuzWJK6hZkGJtuf/Vy4b7xIZeH0iWMa6lMNZihcQZUdvdFhq
+CtOEtC3n2/KacAXb2SgEtlBK8D1DCoMCggEAVypafwslJIId0hyNJmX0QesXSfbT
+AqNSNifeQTby0fqyJUJbslxS6AauQnPwUNEZHiFnRGVJ3FgMNnm7hdDaguVdjS6S
+tgBJmh9PW84RqJm8BNMguUBzUWId4Nh1xDJtI+Klhx8YA2Sfx7nHkabQLAkolmAW
+g/kWgQ+sZowHm8h9KJ84ojqC1LeZKjnvhINPGCXM8JhzPOABsDfl5fNFeK5+xOSG
+erYuWN1BB3Dl3Pal75Ryu7vqk/0uumdRWfqOkf4wgUIZvD+mRdngT9QmK9doT8z7
+iXVBc2YmAuU8hiOFUPxtyQfNzG5fQ0rhJSewdtyWxIadJSLj6fsK+AEsNQ==
+-----END RSA PRIVATE KEY-----"
+                .to_string(),
+            token_uri: "https://oauth2.googleapis.com/token".to_string(),
+        }
+    }
+
+    fn mock_authorized_user() -> AuthorizedUserCredentials {
+        AuthorizedUserCredentials {
+            client_id: "test_client".to_string(),
+            client_secret: "test_secret".to_string(),
+            refresh_token: "test_refresh".to_string(),
+            token_uri: "https://oauth2.googleapis.com/token".to_string(),
+        }
+    }
+
+    // Helper function to create a test GcpAuth instance with credentials
+    async fn create_test_auth_with_creds(creds: AdcCredentials) -> GcpAuth {
+        GcpAuth {
+            credentials: creds,
+            client: reqwest::Client::new(),
+            cached_token: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_token_caching() {
+        let auth = GcpAuth {
+            credentials: AdcCredentials::ServiceAccount(mock_service_account()),
+            client: reqwest::Client::new(),
+            cached_token: Arc::new(RwLock::new(Some(CachedToken {
+                token: AuthToken {
+                    token_type: "Bearer".to_string(),
+                    token_value: "cached_token".to_string(),
+                },
+                expires_at: Instant::now() + Duration::from_secs(3600),
+            }))),
+        };
+
+        // First call should return cached token
+        let token1 = auth.get_token().await.unwrap();
+        assert_eq!(token1.token_value, "cached_token");
+
+        // Second call should return same cached token
+        let token2 = auth.get_token().await.unwrap();
+        assert_eq!(token2.token_value, "cached_token");
+    }
+
+    #[tokio::test]
+    async fn test_token_expiration() {
+        let auth = GcpAuth {
+            credentials: AdcCredentials::ServiceAccount(mock_service_account()),
+            client: reqwest::Client::new(),
+            cached_token: Arc::new(RwLock::new(Some(CachedToken {
+                token: AuthToken {
+                    token_type: "Bearer".to_string(),
+                    token_value: "expired_token".to_string(),
+                },
+                expires_at: Instant::now() - Duration::from_secs(1),
+            }))),
+        };
+
+        // Should fail as token is expired and real credentials aren't available
+        let result = auth.get_token().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_invalid_credentials() {
+        let auth = create_test_auth_with_creds(AdcCredentials::ServiceAccount(
+            ServiceAccountCredentials {
+                client_email: "".to_string(),
+                private_key: "invalid".to_string(),
+                token_uri: "https://invalid.example.com".to_string(),
+            },
+        ))
+        .await;
+
+        let result = auth.get_token().await;
+        assert!(result.is_err());
+        match result {
+            Err(AuthError::TokenCreation(_)) => (),
+            _ => panic!("Expected TokenCreationError"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_token_access() {
+        let auth = Arc::new(GcpAuth {
+            credentials: AdcCredentials::ServiceAccount(mock_service_account()),
+            client: reqwest::Client::new(),
+            cached_token: Arc::new(RwLock::new(Some(CachedToken {
+                token: AuthToken {
+                    token_type: "Bearer".to_string(),
+                    token_value: "concurrent_token".to_string(),
+                },
+                expires_at: Instant::now() + Duration::from_secs(3600),
+            }))),
+        });
+
+        let mut handles = vec![];
+
+        // Spawn multiple concurrent token requests
+        for _ in 0..10 {
+            let auth_clone = Arc::clone(&auth);
+            handles.push(tokio::spawn(async move {
+                auth_clone.get_token().await.unwrap()
+            }));
+        }
+
+        // All requests should return the same cached token
+        for handle in handles {
+            let token = handle.await.unwrap();
+            assert_eq!(token.token_value, "concurrent_token");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_token_refresh_race_condition() {
+        let auth = Arc::new(GcpAuth {
+            credentials: AdcCredentials::ServiceAccount(mock_service_account()),
+            client: reqwest::Client::new(),
+            cached_token: Arc::new(RwLock::new(Some(CachedToken {
+                token: AuthToken {
+                    token_type: "Bearer".to_string(),
+                    token_value: "about_to_expire".to_string(),
+                },
+                expires_at: Instant::now() + Duration::from_millis(100),
+            }))),
+        });
+
+        let mut handles = vec![];
+
+        for i in 0..5 {
+            let auth_clone = Arc::clone(&auth);
+            handles.push(tokio::spawn(async move {
+                sleep(Duration::from_millis(i * 50)).await;
+                let result = auth_clone.get_token().await;
+                match result {
+                    Ok(token) => {
+                        // Should be the cached token since we can't actually exchange tokens in tests
+                        assert_eq!(
+                            token.token_value, "about_to_expire",
+                            "Expected cached token, got: {}",
+                            token.token_value
+                        );
+                    }
+                    Err(e) => {
+                        match e {
+                            AuthError::TokenExchange(err) => {
+                                // This is expected - we can't actually exchange tokens in tests
+                                assert!(
+                                    err.contains("invalid_scope") || err.contains("400"),
+                                    "Unexpected error message: {}",
+                                    err
+                                );
+                            }
+                            other => panic!("Unexpected error type: {:?}", other),
+                        }
+                    }
+                }
+            }));
+        }
+
+        // Wait for all handles
+        for handle in handles {
+            handle.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_authorized_user_token() {
+        let auth = GcpAuth {
+            credentials: AdcCredentials::AuthorizedUser(mock_authorized_user()),
+            client: reqwest::Client::new(),
+            cached_token: Arc::new(RwLock::new(None)),
+        };
+
+        // This should fail since we can't actually make the token exchange request
+        let result = auth.get_token().await;
+        assert!(result.is_err());
+        match result {
+            Err(AuthError::TokenExchange(_)) => (),
+            _ => panic!("Expected TokenExchangeError"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_service_account_jwt_creation() {
+        let auth = GcpAuth {
+            credentials: AdcCredentials::ServiceAccount(mock_service_account()),
+            client: reqwest::Client::new(),
+            cached_token: Arc::new(RwLock::new(None)),
+        };
+
+        let jwt = auth.create_jwt_token(&mock_service_account());
+        assert!(jwt.is_ok(), "JWT creation failed: {:?}", jwt.err());
+        let jwt_str = jwt.unwrap();
+        assert!(jwt_str.starts_with("ey"), "JWT should start with 'ey'");
+        assert_eq!(
+            jwt_str.matches('.').count(),
+            2,
+            "JWT should have exactly 2 dots"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_load_from_env_credentials() {
+        let mut context = TestContext::new();
+
+        // Mock environment variable
+        context
+            .env_mock
+            .expect_get_var()
+            .with(eq("GOOGLE_APPLICATION_CREDENTIALS"))
+            .times(1)
+            .return_once(|_| Ok("/path/to/credentials.json".to_string()));
+
+        // Mock file content - convert &str to String for comparison
+        let creds_content = r#"{
+            "type": "service_account",
+            "client_email": "test@example.com",
+            "private_key": "-----BEGIN PRIVATE KEY-----\nMIIE...test...key\n-----END PRIVATE KEY-----\n",
+            "token_uri": "https://oauth2.googleapis.com/token"
+        }"#;
+
+        context
+            .fs_mock
+            .expect_read_to_string()
+            .with(eq("/path/to/credentials.json".to_string())) // Convert to String
+            .times(1)
+            .return_once(move |_| Ok(creds_content.to_string()));
+
+        let result = AdcCredentials::load_impl(
+            &context.fs_mock,
+            &context.env_mock,
+            "http://metadata.example.com",
+        )
+        .await;
+
+        assert!(result.is_ok());
+        if let Ok(AdcCredentials::ServiceAccount(sa)) = result {
+            assert_eq!(sa.client_email, "test@example.com");
+            assert!(sa.private_key.contains("test...key"));
+        } else {
+            panic!("Expected ServiceAccount credentials");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load_from_default_path() {
+        let mut context = TestContext::new();
+
+        // Mock environment variables
+        context
+            .env_mock
+            .expect_get_var()
+            .with(eq("GOOGLE_APPLICATION_CREDENTIALS"))
+            .times(1)
+            .return_once(|_| Err(env::VarError::NotPresent));
+
+        let home_var = if cfg!(windows) { "APPDATA" } else { "HOME" };
+        context
+            .env_mock
+            .expect_get_var()
+            .with(eq(home_var))
+            .times(1)
+            .return_once(|_| Ok("/home/testuser".to_string()));
+
+        // Mock file content
+        let creds_content = r#"{
+        "type": "authorized_user",
+        "client_id": "test_client",
+        "client_secret": "test_secret",
+        "refresh_token": "test_refresh"
+    }"#;
+
+        let expected_path = if cfg!(windows) {
+            "/home/testuser/gcloud/application_default_credentials.json".to_string()
+        } else {
+            "/home/testuser/.config/gcloud/application_default_credentials.json".to_string()
+        };
+
+        context
+            .fs_mock
+            .expect_read_to_string()
+            .with(eq(expected_path.clone())) // Use clone() to avoid borrowing issues
+            .times(1)
+            .return_once(move |_| Ok(creds_content.to_string()));
+
+        let result = AdcCredentials::load_impl(
+            &context.fs_mock,
+            &context.env_mock,
+            "http://metadata.example.com",
+        )
+        .await;
+
+        assert!(result.is_ok());
+        if let Ok(AdcCredentials::AuthorizedUser(au)) = result {
+            assert_eq!(au.client_id, "test_client");
+            assert_eq!(au.client_secret, "test_secret");
+            assert_eq!(au.refresh_token, "test_refresh");
+        } else {
+            panic!("Expected AuthorizedUser credentials");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load_from_metadata_server() {
+        let mut context = TestContext::new();
+
+        // Mock environment variable lookups to fail
+        context
+            .env_mock
+            .expect_get_var()
+            .with(eq("GOOGLE_APPLICATION_CREDENTIALS"))
+            .times(1)
+            .return_once(|_| Err(env::VarError::NotPresent));
+
+        let home_var = if cfg!(windows) { "APPDATA" } else { "HOME" };
+        context
+            .env_mock
+            .expect_get_var()
+            .with(eq(home_var))
+            .times(1)
+            .return_once(|_| Err(env::VarError::NotPresent));
+
+        // Initialize mock server
+        let context = context.with_metadata_server().await;
+        let mock_server = context
+            .mock_server
+            .as_ref()
+            .expect("Mock server should be initialized");
+
+        // Define expected token values
+        let expected_token = "test_token";
+        let expected_type = "Bearer";
+        let expected_expires = 3600;
+
+        // Configure mock response
+        Mock::given(method("GET"))
+            .and(path(
+                "/computeMetadata/v1/instance/service-accounts/default/token",
+            ))
+            .and(header("Metadata-Flavor", "Google"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": expected_token,
+                "expires_in": expected_expires,
+                "token_type": expected_type,
+            })))
+            .mount(mock_server)
+            .await;
+
+        // Execute the code under test
+        let result =
+            AdcCredentials::load_impl(&context.fs_mock, &context.env_mock, &mock_server.uri())
+                .await;
+
+        // Assertions
+        assert!(
+            result.is_ok(),
+            "Expected successful result, got {:?}",
+            result
+        );
+
+        if let Ok(AdcCredentials::DefaultAccount(token_response)) = result {
+            assert_eq!(token_response.access_token, expected_token);
+            assert_eq!(token_response.token_type, expected_type);
+            assert_eq!(token_response.expires_in, expected_expires);
+        } else {
+            panic!("Expected DefaultAccount credentials, got {:?}", result);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_invalid_credentials_file() {
+        let mut context = TestContext::new();
+
+        // Mock GOOGLE_APPLICATION_CREDENTIALS environment variable
+        context
+            .env_mock
+            .expect_get_var()
+            .with(eq("GOOGLE_APPLICATION_CREDENTIALS"))
+            .times(1)
+            .return_once(|_| Ok("/path/to/credentials.json".to_string()));
+
+        // Mock filesystem read for the invalid credentials file
+        context
+            .fs_mock
+            .expect_read_to_string()
+            .with(eq("/path/to/credentials.json".to_string()))
+            .times(1)
+            .return_once(|_| Ok("invalid json".to_string()));
+
+        // Mock HOME/APPDATA environment variable
+        let home_var = if cfg!(windows) { "APPDATA" } else { "HOME" };
+        context
+            .env_mock
+            .expect_get_var()
+            .with(eq(home_var))
+            .times(1)
+            .return_once(|_| Ok("/home/user".to_string()));
+
+        // Mock filesystem read for the default credentials path
+        let default_creds_path = if cfg!(windows) {
+            "/home/user/gcloud/application_default_credentials.json"
+        } else {
+            "/home/user/.config/gcloud/application_default_credentials.json"
+        };
+        context
+            .fs_mock
+            .expect_read_to_string()
+            .with(eq(default_creds_path.to_string()))
+            .times(1)
+            .return_once(|_| {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "File not found",
+                ))
+            });
+
+        let result = AdcCredentials::load_impl(
+            &context.fs_mock,
+            &context.env_mock,
+            "http://metadata.example.com",
+        )
+        .await;
+
+        assert!(matches!(result, Err(AuthError::Credentials(_))));
+    }
+
+    #[tokio::test]
+    async fn test_no_credentials_found() {
+        let mut context = TestContext::new();
+
+        // Mock all credential sources to fail
+        context
+            .env_mock
+            .expect_get_var()
+            .with(eq("GOOGLE_APPLICATION_CREDENTIALS"))
+            .times(1)
+            .return_once(|_| Err(env::VarError::NotPresent));
+
+        context
+            .env_mock
+            .expect_get_var()
+            .with(eq(if cfg!(windows) { "APPDATA" } else { "HOME" }))
+            .times(1)
+            .return_once(|_| Err(env::VarError::NotPresent));
+
+        let result = AdcCredentials::load_impl(
+            &context.fs_mock,
+            &context.env_mock,
+            "http://metadata.example.com",
+        )
+        .await;
+        assert!(matches!(result, Err(AuthError::Credentials(_))));
+    }
+}

--- a/crates/leaf/src/providers/gcpvertexai.rs
+++ b/crates/leaf/src/providers/gcpvertexai.rs
@@ -1,0 +1,799 @@
+use std::io;
+use std::time::Duration;
+
+use anyhow::Result;
+use async_stream::try_stream;
+use async_trait::async_trait;
+use futures::future::BoxFuture;
+use futures::StreamExt;
+use futures::TryStreamExt;
+use once_cell::sync::Lazy;
+use reqwest::{Client, StatusCode};
+use serde_json::Value;
+use tokio::time::sleep;
+use tokio_util::io::StreamReader;
+use url::Url;
+
+use crate::conversation::message::Message;
+use crate::model::ModelConfig;
+use crate::providers::base::{ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata};
+
+use crate::providers::errors::ProviderError;
+use crate::providers::formats::gcpvertexai::{
+    create_request, response_to_streaming_message, GcpLocation, ModelProvider, RequestContext,
+    DEFAULT_MODEL, KNOWN_MODELS,
+};
+use crate::providers::gcpauth::GcpAuth;
+use crate::providers::openai_compatible::map_http_error_to_provider_error;
+use crate::providers::retry::RetryConfig;
+use crate::providers::utils::RequestLog;
+use crate::session_context::SESSION_ID_HEADER;
+use rmcp::model::Tool;
+
+const GCP_VERTEX_AI_PROVIDER_NAME: &str = "gcp_vertex_ai";
+/// Base URL for GCP Vertex AI documentation
+const GCP_VERTEX_AI_DOC_URL: &str = "https://cloud.google.com/vertex-ai";
+/// Default timeout for API requests in seconds
+const DEFAULT_TIMEOUT_SECS: u64 = 600;
+/// Default initial interval for retry (in milliseconds)
+const DEFAULT_INITIAL_RETRY_INTERVAL_MS: u64 = 5000;
+/// Default maximum number of retries
+const DEFAULT_MAX_RETRIES: usize = 6;
+/// Default retry backoff multiplier
+const DEFAULT_BACKOFF_MULTIPLIER: f64 = 2.0;
+/// Default maximum interval for retry (in milliseconds)
+const DEFAULT_MAX_RETRY_INTERVAL_MS: u64 = 320_000;
+/// Status code for Anthropic's API overloaded error (529)
+static STATUS_API_OVERLOADED: Lazy<StatusCode> =
+    Lazy::new(|| StatusCode::from_u16(529).expect("Valid status code 529 for API_OVERLOADED"));
+
+fn rate_limit_error_message(response_text: &str) -> String {
+    let cite = "See https://cloud.google.com/vertex-ai/generative-ai/docs/error-code-429";
+    if response_text.contains("Exceeded the Provisioned Throughput") {
+        format!("Exceeded the Provisioned Throughput: {cite}")
+    } else {
+        format!("Pay-as-you-go resource exhausted: {cite}")
+    }
+}
+
+const OVERLOADED_ERROR_MSG: &str =
+    "Vertex AI Provider API is temporarily overloaded. This is similar to a rate limit \
+     error but indicates backend processing capacity issues.";
+
+fn build_vertex_url(
+    host: &str,
+    configured_location: &str,
+    project_id: &str,
+    model_name: &str,
+    provider: ModelProvider,
+    target_location: &str,
+    streaming: bool,
+) -> Result<Url, GcpVertexAIError> {
+    let host_url = if configured_location == target_location {
+        host.to_string()
+    } else {
+        GcpVertexAIProvider::build_host_url(target_location)
+    };
+
+    let base_url =
+        Url::parse(&host_url).map_err(|e| GcpVertexAIError::InvalidUrl(e.to_string()))?;
+
+    let endpoint = match (&provider, streaming) {
+        (ModelProvider::Anthropic, true) => "streamRawPredict",
+        (ModelProvider::Anthropic, false) => "rawPredict",
+        (ModelProvider::Google, true) => "streamGenerateContent",
+        (ModelProvider::Google, false) => "generateContent",
+        (ModelProvider::MaaS(_), true) => "streamGenerateContent",
+        (ModelProvider::MaaS(_), false) => "generateContent",
+    };
+
+    let path = format!(
+        "v1/projects/{}/locations/{}/publishers/{}/models/{}:{}",
+        project_id,
+        target_location,
+        provider.as_str(),
+        model_name,
+        endpoint
+    );
+
+    let mut url = base_url
+        .join(&path)
+        .map_err(|e| GcpVertexAIError::InvalidUrl(e.to_string()))?;
+
+    if streaming && !matches!(provider, ModelProvider::Anthropic) {
+        url.set_query(Some("alt=sse"));
+    }
+
+    Ok(url)
+}
+
+/// Represents errors specific to GCP Vertex AI operations.
+#[derive(Debug, thiserror::Error)]
+enum GcpVertexAIError {
+    /// Error when URL construction fails
+    #[error("Invalid URL configuration: {0}")]
+    InvalidUrl(String),
+
+    /// Error during GCP authentication
+    #[error("Authentication error: {0}")]
+    AuthError(String),
+}
+
+/// Provider implementation for Google Cloud Platform's Vertex AI service.
+///
+/// This provider enables interaction with various AI models hosted on GCP Vertex AI,
+/// including Claude and Gemini model families. It handles authentication, request routing,
+/// and response processing for the Vertex AI API endpoints.
+#[derive(Debug, serde::Serialize)]
+pub struct GcpVertexAIProvider {
+    /// HTTP client for making API requests
+    #[serde(skip)]
+    client: Client,
+    /// GCP authentication handler
+    #[serde(skip)]
+    auth: GcpAuth,
+    /// Base URL for the Vertex AI API
+    host: String,
+    /// GCP project identifier
+    project_id: String,
+    /// GCP region for model deployment
+    location: String,
+    /// Configuration for the specific model being used
+    model: ModelConfig,
+    /// Retry configuration for handling rate limit errors
+    #[serde(skip)]
+    retry_config: RetryConfig,
+    #[serde(skip)]
+    name: String,
+}
+
+impl GcpVertexAIProvider {
+    /// Creates a new provider instance from environment configuration.
+    ///
+    /// This is a convenience method that initializes the provider using
+    /// environment variables and default settings.
+    ///
+    /// # Arguments
+    /// * `model` - Configuration for the model to be used
+    pub async fn from_env(model: ModelConfig) -> Result<Self> {
+        let config = crate::config::Config::global();
+        let project_id = config.get_param("GCP_PROJECT_ID")?;
+        let location = Self::determine_location(config)?;
+        let host = Self::build_host_url(&location);
+
+        let client = Client::builder()
+            .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+            .build()?;
+
+        let auth = GcpAuth::new().await?;
+
+        // Load optional retry configuration from environment
+        let retry_config = Self::load_retry_config(config);
+
+        Ok(Self {
+            client,
+            auth,
+            host,
+            project_id,
+            location,
+            model,
+            retry_config,
+            name: GCP_VERTEX_AI_PROVIDER_NAME.to_string(),
+        })
+    }
+
+    /// Loads retry configuration from environment variables or uses defaults.
+    fn load_retry_config(config: &crate::config::Config) -> RetryConfig {
+        // Load max retries for 429 rate limit errors
+        let max_retries = config
+            .get_param("GCP_MAX_RETRIES")
+            .ok()
+            .and_then(|v: String| v.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_MAX_RETRIES);
+
+        let initial_interval_ms = config
+            .get_param("GCP_INITIAL_RETRY_INTERVAL_MS")
+            .ok()
+            .and_then(|v: String| v.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_INITIAL_RETRY_INTERVAL_MS);
+
+        let backoff_multiplier = config
+            .get_param("GCP_BACKOFF_MULTIPLIER")
+            .ok()
+            .and_then(|v: String| v.parse::<f64>().ok())
+            .unwrap_or(DEFAULT_BACKOFF_MULTIPLIER);
+
+        let max_interval_ms = config
+            .get_param("GCP_MAX_RETRY_INTERVAL_MS")
+            .ok()
+            .and_then(|v: String| v.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_MAX_RETRY_INTERVAL_MS);
+
+        RetryConfig::new(
+            max_retries,
+            initial_interval_ms,
+            backoff_multiplier,
+            max_interval_ms,
+        )
+    }
+
+    /// Determines the appropriate GCP location for model deployment.
+    ///
+    /// Location is determined in the following order:
+    /// 1. Custom location from GCP_LOCATION environment variable
+    /// 2. Global default location (Iowa)
+    fn determine_location(config: &crate::config::Config) -> Result<String> {
+        Ok(config
+            .get_param("GCP_LOCATION")
+            .ok()
+            .filter(|location: &String| !location.trim().is_empty())
+            .unwrap_or_else(|| GcpLocation::Iowa.to_string()))
+    }
+
+    fn build_host_url(location: &str) -> String {
+        if location == "global" {
+            "https://aiplatform.googleapis.com".to_string()
+        } else {
+            format!("https://{}-aiplatform.googleapis.com", location)
+        }
+    }
+
+    /// Retrieves an authentication token for API requests.
+    async fn get_auth_header(&self) -> Result<String, GcpVertexAIError> {
+        self.auth
+            .get_token()
+            .await
+            .map(|token| format!("Bearer {}", token.token_value))
+            .map_err(|e| GcpVertexAIError::AuthError(e.to_string()))
+    }
+
+    fn build_request_url(
+        &self,
+        provider: ModelProvider,
+        location: &str,
+        streaming: bool,
+    ) -> Result<Url, GcpVertexAIError> {
+        build_vertex_url(
+            &self.host,
+            &self.location,
+            &self.project_id,
+            &self.model.model_name,
+            provider,
+            location,
+            streaming,
+        )
+    }
+
+    async fn send_request_with_retry(
+        &self,
+        session_id: Option<&str>,
+        url: Url,
+        payload: &Value,
+    ) -> Result<reqwest::Response, ProviderError> {
+        let mut rate_limit_attempts = 0;
+        let mut overloaded_attempts = 0;
+        let mut last_error = None;
+        let max_retries = self.retry_config.max_retries;
+
+        loop {
+            if rate_limit_attempts > max_retries && overloaded_attempts > max_retries {
+                return Err(
+                    last_error.unwrap_or_else(|| ProviderError::RateLimitExceeded {
+                        details: format!("Exceeded maximum retry attempts ({max_retries})"),
+                        retry_delay: None,
+                    }),
+                );
+            }
+
+            let auth_header = self
+                .get_auth_header()
+                .await
+                .map_err(|e| ProviderError::Authentication(e.to_string()))?;
+
+            let mut request = self
+                .client
+                .post(url.clone())
+                .json(payload)
+                .header("Authorization", auth_header);
+
+            if let Some(session_id) = session_id.filter(|id| !id.is_empty()) {
+                request = request.header(SESSION_ID_HEADER, session_id);
+            }
+
+            let response = request
+                .send()
+                .await
+                .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+
+            let status = response.status();
+
+            if status == StatusCode::TOO_MANY_REQUESTS {
+                rate_limit_attempts += 1;
+                if rate_limit_attempts > max_retries {
+                    return Err(
+                        last_error.unwrap_or_else(|| ProviderError::RateLimitExceeded {
+                            details: format!("Exceeded max retries ({max_retries}) for 429"),
+                            retry_delay: None,
+                        }),
+                    );
+                }
+                let msg = rate_limit_error_message(&response.text().await.unwrap_or_default());
+                tracing::warn!("429 (attempt {rate_limit_attempts}/{max_retries}): {msg}");
+                last_error = Some(ProviderError::RateLimitExceeded {
+                    details: msg,
+                    retry_delay: None,
+                });
+                sleep(self.retry_config.delay_for_attempt(rate_limit_attempts)).await;
+            } else if status == *STATUS_API_OVERLOADED {
+                overloaded_attempts += 1;
+                if overloaded_attempts > max_retries {
+                    return Err(
+                        last_error.unwrap_or_else(|| ProviderError::RateLimitExceeded {
+                            details: format!("Exceeded max retries ({max_retries}) for 529"),
+                            retry_delay: None,
+                        }),
+                    );
+                }
+                tracing::warn!(
+                    "529 (attempt {overloaded_attempts}/{max_retries}): {OVERLOADED_ERROR_MSG}"
+                );
+                last_error = Some(ProviderError::RateLimitExceeded {
+                    details: OVERLOADED_ERROR_MSG.to_string(),
+                    retry_delay: None,
+                });
+                sleep(self.retry_config.delay_for_attempt(overloaded_attempts)).await;
+            } else if status == StatusCode::OK {
+                return Ok(response);
+            } else if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
+                return Err(ProviderError::Authentication(format!(
+                    "Authentication failed with status: {status}"
+                )));
+            } else {
+                let response_text = response.text().await.unwrap_or_default();
+                let payload = serde_json::from_str::<Value>(&response_text).ok();
+                return Err(map_http_error_to_provider_error(status, payload));
+            }
+        }
+    }
+
+    async fn post_stream_with_location(
+        &self,
+        session_id: Option<&str>,
+        payload: &Value,
+        context: &RequestContext,
+        location: &str,
+    ) -> Result<reqwest::Response, ProviderError> {
+        let url = self
+            .build_request_url(context.provider(), location, true)
+            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+
+        self.send_request_with_retry(session_id, url, payload).await
+    }
+
+    async fn post_stream(
+        &self,
+        session_id: Option<&str>,
+        payload: &Value,
+        context: &RequestContext,
+    ) -> Result<reqwest::Response, ProviderError> {
+        let result = self
+            .post_stream_with_location(session_id, payload, context, &self.location)
+            .await;
+
+        if self.location == context.model.known_location().to_string() || result.is_ok() {
+            return result;
+        }
+
+        match &result {
+            Err(ProviderError::RequestFailed(msg)) => {
+                let model_name = context.model.to_string();
+                let configured_location = &self.location;
+                let known_location = context.model.known_location().to_string();
+
+                tracing::warn!(
+                    "Trying known location {known_location} for {model_name} instead of {configured_location}: {msg}"
+                );
+
+                self.post_stream_with_location(session_id, payload, context, &known_location)
+                    .await
+            }
+            _ => result,
+        }
+    }
+
+    async fn filter_by_org_policy(&self, models: Vec<String>) -> Vec<String> {
+        let Ok(auth_header) = self.get_auth_header().await else {
+            tracing::debug!("Could not get auth header for org policy check, returning all models");
+            return models;
+        };
+
+        let url = format!(
+            "https://cloudresourcemanager.googleapis.com/v1/projects/{}:getEffectiveOrgPolicy",
+            self.project_id
+        );
+
+        let payload = serde_json::json!({
+            "constraint": "constraints/vertexai.allowedModels"
+        });
+
+        let response = match self
+            .client
+            .post(&url)
+            .header("Authorization", &auth_header)
+            .json(&payload)
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::debug!("Failed to fetch org policy: {e}, returning all models");
+                return models;
+            }
+        };
+
+        let json = match response.json::<Value>().await {
+            Ok(j) => j,
+            Err(e) => {
+                tracing::debug!("Failed to parse org policy response: {e}, returning all models");
+                return models;
+            }
+        };
+
+        let allowed_patterns: Vec<String> = json
+            .get("listPolicy")
+            .and_then(|lp| lp.get("allowedValues"))
+            .and_then(|av| av.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        if allowed_patterns.is_empty() {
+            return models;
+        }
+
+        models
+            .into_iter()
+            .filter(|model| Self::is_model_allowed(model, &allowed_patterns))
+            .collect()
+    }
+
+    fn is_model_allowed(model: &str, allowed_patterns: &[String]) -> bool {
+        let publisher = if model.starts_with("claude-") {
+            "anthropic"
+        } else if model.starts_with("gemini-") {
+            "google"
+        } else {
+            return true;
+        };
+
+        for pattern in allowed_patterns {
+            if pattern.contains(&format!("publishers/{publisher}/models/*")) {
+                return true;
+            }
+
+            let pattern_model = pattern
+                .split("/models/")
+                .nth(1)
+                .map(|s| s.trim_end_matches(":predict").trim_end_matches(":*"));
+
+            if let Some(pattern_model) = pattern_model {
+                if model == pattern_model || model.starts_with(&format!("{pattern_model}@")) {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+}
+
+impl ProviderDef for GcpVertexAIProvider {
+    type Provider = Self;
+
+    fn metadata() -> ProviderMetadata {
+        ProviderMetadata::new(
+            GCP_VERTEX_AI_PROVIDER_NAME,
+            "GCP Vertex AI",
+            "Access variety of AI models such as Claude, Gemini through Vertex AI",
+            DEFAULT_MODEL,
+            KNOWN_MODELS.to_vec(),
+            GCP_VERTEX_AI_DOC_URL,
+            vec![
+                ConfigKey::new("GCP_PROJECT_ID", true, false, None, true),
+                ConfigKey::new(
+                    "GCP_LOCATION",
+                    true,
+                    false,
+                    Some(&GcpLocation::Iowa.to_string()),
+                    true,
+                ),
+                ConfigKey::new(
+                    "GCP_MAX_RETRIES",
+                    false,
+                    false,
+                    Some(&DEFAULT_MAX_RETRIES.to_string()),
+                    false,
+                ),
+                ConfigKey::new(
+                    "GCP_INITIAL_RETRY_INTERVAL_MS",
+                    false,
+                    false,
+                    Some(&DEFAULT_INITIAL_RETRY_INTERVAL_MS.to_string()),
+                    false,
+                ),
+                ConfigKey::new(
+                    "GCP_BACKOFF_MULTIPLIER",
+                    false,
+                    false,
+                    Some(&DEFAULT_BACKOFF_MULTIPLIER.to_string()),
+                    false,
+                ),
+                ConfigKey::new(
+                    "GCP_MAX_RETRY_INTERVAL_MS",
+                    false,
+                    false,
+                    Some(&DEFAULT_MAX_RETRY_INTERVAL_MS.to_string()),
+                    false,
+                ),
+            ],
+        )
+    }
+
+    fn from_env(
+        model: ModelConfig,
+        _extensions: Vec<crate::config::ExtensionConfig>,
+    ) -> BoxFuture<'static, Result<Self::Provider>> {
+        Box::pin(Self::from_env(model))
+    }
+}
+
+#[async_trait]
+impl Provider for GcpVertexAIProvider {
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    /// Completes a model interaction by sending a request and processing the response.
+    ///
+    /// # Arguments
+    /// * `system` - System prompt or context
+    /// * `messages` - Array of previous messages in the conversation
+    /// * `tools` - Array of available tools for the model
+    /// Returns the current model configuration.
+    fn get_model_config(&self) -> ModelConfig {
+        self.model.clone()
+    }
+
+    async fn stream(
+        &self,
+        model_config: &ModelConfig,
+        session_id: &str,
+        system: &str,
+        messages: &[Message],
+        tools: &[Tool],
+    ) -> Result<MessageStream, ProviderError> {
+        let (mut request, context) = create_request(model_config, system, messages, tools)?;
+
+        if matches!(context.provider(), ModelProvider::Anthropic) {
+            if let Some(obj) = request.as_object_mut() {
+                obj.insert("stream".to_string(), Value::Bool(true));
+            }
+        }
+
+        let mut log = RequestLog::start(model_config, &request)?;
+
+        let response = self
+            .post_stream(Some(session_id), &request, &context)
+            .await
+            .inspect_err(|e| {
+                let _ = log.error(e);
+            })?;
+
+        let stream = response.bytes_stream().map_err(io::Error::other);
+
+        let context_clone = context.clone();
+        Ok(Box::pin(try_stream! {
+            let stream_reader = StreamReader::new(stream);
+            let framed = tokio_util::codec::FramedRead::new(
+                stream_reader,
+                tokio_util::codec::LinesCodec::new(),
+            )
+            .map_err(anyhow::Error::from);
+
+            let mut message_stream = response_to_streaming_message(framed, &context_clone);
+
+            while let Some(message) = message_stream.next().await {
+                let (message, usage) = message
+                    .map_err(|e| ProviderError::RequestFailed(format!("Stream decode error: {}", e)))?;
+                log.write(&message, usage.as_ref().map(|u| &u.usage))?;
+                yield (message, usage);
+            }
+        }))
+    }
+
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
+        let models: Vec<String> = KNOWN_MODELS.iter().map(|s| s.to_string()).collect();
+        let filtered = self.filter_by_org_policy(models).await;
+        Ok(filtered)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::StatusCode;
+
+    #[test]
+    fn test_retry_config_delay_calculation() {
+        let config = RetryConfig::new(5, 1000, 2.0, 32000);
+
+        // First attempt has no delay
+        let delay0 = config.delay_for_attempt(0);
+        assert_eq!(delay0.as_millis(), 0);
+
+        // First retry should be around initial_interval with jitter
+        let delay1 = config.delay_for_attempt(1);
+        assert!(delay1.as_millis() >= 800 && delay1.as_millis() <= 1200);
+
+        // Second retry should be around initial_interval * multiplier^1 with jitter
+        let delay2 = config.delay_for_attempt(2);
+        assert!(delay2.as_millis() >= 1600 && delay2.as_millis() <= 2400);
+
+        // Check that max interval is respected
+        let delay10 = config.delay_for_attempt(10);
+        assert!(delay10.as_millis() <= 38400); // max_interval_ms * 1.2 (max jitter)
+    }
+
+    #[test]
+    fn test_status_overloaded_code() {
+        // Test that we correctly handle the 529 status code
+
+        // Verify the custom status code is created correctly
+        assert_eq!(STATUS_API_OVERLOADED.as_u16(), 529);
+
+        // This is not a standard HTTP status code, so it's classified as server error
+        assert!(STATUS_API_OVERLOADED.is_server_error());
+
+        // Should be different from TOO_MANY_REQUESTS (429)
+        assert_ne!(*STATUS_API_OVERLOADED, StatusCode::TOO_MANY_REQUESTS);
+
+        // Should be different from SERVICE_UNAVAILABLE (503)
+        assert_ne!(*STATUS_API_OVERLOADED, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn test_model_provider_conversion() {
+        assert_eq!(ModelProvider::Anthropic.as_str(), "anthropic".to_string());
+        assert_eq!(ModelProvider::Google.as_str(), "google".to_string());
+        assert_eq!(
+            ModelProvider::MaaS("qwen".to_string()).as_str(),
+            "qwen".to_string()
+        );
+    }
+
+    #[test]
+    fn test_build_vertex_url_endpoints() {
+        let anthropic_url = build_vertex_url(
+            "https://us-east5-aiplatform.googleapis.com",
+            "us-east5",
+            "test-project",
+            "claude-sonnet-4@20250514",
+            ModelProvider::Anthropic,
+            "us-east5",
+            false,
+        )
+        .unwrap();
+        assert!(anthropic_url.as_str().contains(":rawPredict"));
+
+        let anthropic_stream = build_vertex_url(
+            "https://us-east5-aiplatform.googleapis.com",
+            "us-east5",
+            "test-project",
+            "claude-sonnet-4@20250514",
+            ModelProvider::Anthropic,
+            "us-east5",
+            true,
+        )
+        .unwrap();
+        assert!(anthropic_stream.as_str().contains(":streamRawPredict"));
+        assert!(anthropic_stream.query().is_none());
+
+        let google_stream = build_vertex_url(
+            "https://us-central1-aiplatform.googleapis.com",
+            "us-central1",
+            "test-project",
+            "gemini-2.5-flash",
+            ModelProvider::Google,
+            "us-central1",
+            true,
+        )
+        .unwrap();
+        assert!(google_stream.as_str().contains(":streamGenerateContent"));
+        assert_eq!(google_stream.query(), Some("alt=sse"));
+    }
+
+    #[test]
+    fn test_build_vertex_url_location_replacement() {
+        let url = build_vertex_url(
+            "https://us-east5-aiplatform.googleapis.com",
+            "us-east5",
+            "test-project",
+            "claude-sonnet-4@20250514",
+            ModelProvider::Anthropic,
+            "europe-west1",
+            false,
+        )
+        .unwrap();
+
+        assert!(url
+            .as_str()
+            .contains("europe-west1-aiplatform.googleapis.com"));
+        assert!(url.as_str().contains("locations/europe-west1"));
+    }
+
+    #[test]
+    fn test_build_vertex_url_global_location_fallback() {
+        // When configured_location is "global", the host is
+        // "https://aiplatform.googleapis.com" which does not contain "global".
+        // Falling back to a regional target_location must rebuild the host
+        // via build_host_url rather than string replacement.
+        let url = build_vertex_url(
+            "https://aiplatform.googleapis.com",
+            "global",
+            "test-project",
+            "claude-haiku-4-5@20251001",
+            ModelProvider::Anthropic,
+            "us-east5",
+            true,
+        )
+        .unwrap();
+
+        assert!(
+            url.as_str()
+                .starts_with("https://us-east5-aiplatform.googleapis.com"),
+            "Expected regional host for us-east5, got: {}",
+            url
+        );
+        assert!(
+            url.as_str().contains("locations/us-east5"),
+            "Expected locations/us-east5 in path, got: {}",
+            url
+        );
+        assert!(url.as_str().contains(":streamRawPredict"));
+    }
+
+    #[test]
+    fn test_build_vertex_url_global_location_same() {
+        // When both configured and target are "global", the host should stay as-is.
+        let url = build_vertex_url(
+            "https://aiplatform.googleapis.com",
+            "global",
+            "test-project",
+            "claude-haiku-4-5@20251001",
+            ModelProvider::Anthropic,
+            "global",
+            true,
+        )
+        .unwrap();
+
+        assert!(
+            url.as_str()
+                .starts_with("https://aiplatform.googleapis.com"),
+            "Expected global host, got: {}",
+            url
+        );
+        assert!(url.as_str().contains("locations/global"));
+    }
+
+    #[test]
+    fn test_provider_metadata() {
+        let metadata = GcpVertexAIProvider::metadata();
+        assert!(!metadata.known_models.is_empty());
+        assert_eq!(metadata.default_model, "gemini-2.5-flash");
+        assert_eq!(metadata.config_keys.len(), 6);
+    }
+}

--- a/crates/leaf/src/providers/gemini_acp.rs
+++ b/crates/leaf/src/providers/gemini_acp.rs
@@ -14,6 +14,7 @@ use crate::model::ModelConfig;
 use crate::providers::base::{ProviderDef, ProviderMetadata};
 
 const GEMINI_ACP_PROVIDER_NAME: &str = "gemini-acp";
+pub const GEMINI_ACP_DEFAULT_MODEL: &str = "current";
 const GEMINI_ACP_DOC_URL: &str = "https://github.com/google-gemini/gemini-cli";
 
 pub struct GeminiAcpProvider;

--- a/crates/leaf/src/providers/init.rs
+++ b/crates/leaf/src/providers/init.rs
@@ -7,6 +7,7 @@ use super::{
     chatgpt_codex::ChatGptCodexProvider,
     claude_acp::ClaudeAcpProvider,
     codex_acp::CodexAcpProvider,
+    copilot_acp::CopilotAcpProvider,
     cursor_agent::CursorAgentProvider,
     databricks::DatabricksProvider,
     gemini_acp::GeminiAcpProvider,
@@ -45,6 +46,7 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
         registry.register::<ClaudeAcpProvider>(false);
         registry.register::<GeminiAcpProvider>(false);
         registry.register::<CodexAcpProvider>(false);
+        registry.register::<CopilotAcpProvider>(false);
         registry.register::<CursorAgentProvider>(false);
         registry.register::<DatabricksProvider>(true);
         registry.register::<GeminiCliProvider>(false);

--- a/crates/leaf/src/providers/init.rs
+++ b/crates/leaf/src/providers/init.rs
@@ -10,6 +10,7 @@ use super::{
     copilot_acp::CopilotAcpProvider,
     cursor_agent::CursorAgentProvider,
     databricks::DatabricksProvider,
+    gcpvertexai::GcpVertexAIProvider,
     gemini_acp::GeminiAcpProvider,
     gemini_cli::GeminiCliProvider,
     githubcopilot::GithubCopilotProvider,
@@ -49,6 +50,7 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
         registry.register::<CopilotAcpProvider>(false);
         registry.register::<CursorAgentProvider>(false);
         registry.register::<DatabricksProvider>(true);
+        registry.register::<GcpVertexAIProvider>(false);
         registry.register::<GeminiCliProvider>(false);
         registry.register::<GithubCopilotProvider>(false);
         registry.register::<GoogleProvider>(true);

--- a/crates/leaf/src/providers/mod.rs
+++ b/crates/leaf/src/providers/mod.rs
@@ -16,6 +16,8 @@ pub mod databricks;
 pub mod embedding;
 pub mod errors;
 pub mod formats;
+pub mod gcpauth;
+pub mod gcpvertexai;
 pub mod gemini_acp;
 pub mod gemini_cli;
 pub mod githubcopilot;

--- a/crates/leaf/src/providers/mod.rs
+++ b/crates/leaf/src/providers/mod.rs
@@ -10,6 +10,7 @@ pub mod chatgpt_codex;
 pub mod claude_acp;
 pub(crate) mod cli_common;
 pub mod codex_acp;
+pub mod copilot_acp;
 pub mod cursor_agent;
 pub mod databricks;
 pub mod embedding;

--- a/crates/leaf/tests/providers.rs
+++ b/crates/leaf/tests/providers.rs
@@ -810,6 +810,14 @@ async fn test_codex_acp_provider() -> Result<()> {
         .await
 }
 
+// Requires: npm install -g @github/copilot
+#[tokio::test]
+async fn test_copilot_acp_provider() -> Result<()> {
+    ProviderTestConfig::with_agentic_provider("copilot-acp", "current", "copilot")
+        .run()
+        .await
+}
+
 // Requires: npm install -g @google/gemini-cli
 #[tokio::test]
 async fn test_gemini_acp_provider() -> Result<()> {

--- a/evals/open-model-gym/mcp-harness/package-lock.json
+++ b/evals/open-model-gym/mcp-harness/package-lock.json
@@ -814,8 +814,8 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
       "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
       "license": "MIT",
       "funding": {


### PR DESCRIPTION
## Upstream Migration: `582582159..bc296816b`

Adopting CLI-relevant commits from `block/goose` main branch with goose→leaf renaming.

### 5 Commits Adopted

| # | Commit | Description |
|---|--------|-------------|
| 1 | `1d2259a5b` | chore(deps): bump path-to-regexp 8.3.0→8.4.0 |
| 2 | `f8e5667ca` | fix(openai): use safely_parse_json for streaming tool arguments |
| 3 | `a8a84f125` | feat: add copilot-acp provider (goose→leaf renamed) |
| 4 | `2a5e499c1` | ci: add Windows build job, only run on main branch pushes |
| 5 | `fd0ebb057` | fix: add GCP Vertex AI provider with build_host_url location fallback |

### 6 Commits Skipped

| Commit | Reason |
|--------|--------|
| `0469af7f3` | Blog post — `documentation/` not in fork |
| `73b542c38` | i18n windows fix — `ui/desktop/scripts/` not in fork |
| `074f8312b` | npm publish auth — `publish-npm.yml` not in fork |
| `e3b78e8e8` | Remove `.npmrc` — `ui/acp/` not in fork |
| `5b47740d7` | Welcome route removal — `ui/desktop/` not in fork |
| `b860e0f26` | Privacy modal simplification — `ui/desktop/` not in fork |

### Verification
- ✅ `cargo check -p leaf --no-default-features` passes
- ✅ `cargo clippy -p leaf --no-default-features -- -D warnings` passes
- ✅ `cargo fmt --check` passes

Closes #39