### PR TITLE
fix: use provider registry context limits as fallback for ModelConfig

### DIFF
--- a/crates/leaf/src/providers/init.rs
+++ b/crates/leaf/src/providers/init.rs
@@ -142,7 +142,9 @@ pub async fn create(
     model: ModelConfig,
     extensions: Vec<ExtensionConfig>,
 ) -> Result<Arc<dyn Provider>> {
-    let constructor = get_from_registry(name).await?.constructor.clone();
+    let entry = get_from_registry(name).await?;
+    let model = entry.enrich_context_limit(model);
+    let constructor = entry.constructor.clone();
     constructor(model, extensions).await
 }
 
@@ -175,8 +177,11 @@ pub async fn create_with_named_model(
     model_name: &str,
     extensions: Vec<ExtensionConfig>,
 ) -> Result<Arc<dyn Provider>> {
+    let entry = get_from_registry(provider_name).await?;
     let config = ModelConfig::new(model_name)?.with_canonical_limits(provider_name);
-    create(provider_name, config, extensions).await
+    let config = entry.enrich_context_limit(config);
+    let constructor = entry.constructor.clone();
+    constructor(config, extensions).await
 }
 
 #[cfg(test)]

--- a/crates/leaf/src/providers/provider_registry.rs
+++ b/crates/leaf/src/providers/provider_registry.rs
@@ -34,7 +34,21 @@ impl ProviderEntry {
         let provider_name = &self.metadata.name;
         let model_config =
             ModelConfig::new(default_model.as_str())?.with_canonical_limits(provider_name);
+        let model_config = self.enrich_context_limit(model_config);
         (self.constructor)(model_config, extensions).await
+    }
+
+    pub fn enrich_context_limit(&self, config: ModelConfig) -> ModelConfig {
+        if config.context_limit.is_some() {
+            return config;
+        }
+        let limit = self
+            .metadata
+            .known_models
+            .iter()
+            .find(|m| m.name == config.model_name)
+            .map(|m| m.context_limit);
+        config.with_context_limit(limit)
     }
 
     pub fn with_fallback_display_name(&self, original_name: &str) -> Self {


### PR DESCRIPTION
## Problem

When switching to a model from an opencode provider (e.g. `glm-5.1`), the progress bar shows incorrect context limits:

```
Current model: opencode-zhipuai-coding-plan-openai-compatible/glm-5.1
  ━━━━━╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ 23% 29k/128k   ← wrong, should be 195k
```

## Root Cause

Two separate code paths for context limits:
1. **`/model` list** → reads from `ProviderMetadata.known_models` (runtime data from models.dev) ✅
2. **`ModelConfig::context_limit()`** → resolved from bundled `canonical_models.json` ❌

For opencode providers, `canonical_models.json` is stale and does not contain all runtime models (e.g. `glm-5.1`). When the canonical lookup fails, `context_limit` stays `None` and `context_limit()` returns `DEFAULT_CONTEXT_LIMIT` (128K).

## Fix (Option C from #43)

Added `ProviderEntry::enrich_context_limit()` — a fallback that checks if `context_limit` is already set by canonical data. If not, it looks up the model in the provider's `known_models` metadata (populated from runtime data) and applies the correct limit.

### Changes

- **`provider_registry.rs`**: Added `enrich_context_limit()` method + applied it in `create_with_default_model()`
- **`init.rs`**: All three creation paths now enrich context_limit:
  - `create()` — covers new sessions and session builder
  - `create_with_default_model()` — covers default model selection
  - `create_with_named_model()` — covers `/model` command switch

### Coverage matrix

| Path | Function | Enriched? |
|------|----------|-----------|
| New session | `builder.rs` → `create()` | ✅ |
| `/model` switch | `mod.rs` → `create_with_named_model()` | ✅ |
| Default model | `create_with_default_model()` | ✅ |
| Resume, same model | restored from saved session data | ✅ |
| Resume, model changed | `builder.rs` → `create()` | ✅ |

### Flow after fix

```
ModelConfig::new("glm-5.1")
  → with_canonical_limits("opencode-zhipuai-coding-plan-openai-compatible")
    → canonical lookup fails → context_limit = None
  → enrich_context_limit(config)
    → looks up "glm-5.1" in provider metadata known_models
    → found: context_limit = 195000 → sets it ✅
```

Closes #43
