### PR TITLE
feat: group session list by working directory

### DIFF
--- a/crates/leaf-cli/src/commands/session.rs
+++ b/crates/leaf-cli/src/commands/session.rs
@@ -6,6 +6,7 @@ use etcetera::home_dir;
 use leaf::session::{generate_diagnostics, Session, SessionManager};
 use leaf::utils::safe_truncate;
 use regex::Regex;
+use std::collections::BTreeMap;
 use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
@@ -169,15 +170,14 @@ pub async fn handle_session_list(
         sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
     }
 
-    if let Some(n) = limit {
-        sessions.truncate(n);
-    }
-
     let stdout = io::stdout();
     let mut out = stdout.lock();
 
     match format.as_str() {
         "json" => {
+            if let Some(n) = limit {
+                sessions.truncate(n);
+            }
             let payload = serde_json::to_string(&sessions)?;
             if !write_line_or_broken_pipe_ok(&mut out, &payload)? {
                 return Ok(());
@@ -191,21 +191,79 @@ pub async fn handle_session_list(
                 return Ok(());
             }
 
-            if !write_line_or_broken_pipe_ok(&mut out, "Available sessions:")? {
+            if !write_line_or_broken_pipe_ok(&mut out, "Available sessions:\n")? {
                 return Ok(());
             }
 
-            for session in sessions {
-                let output = format!(
-                    "{} - {} - {} - {}",
-                    session.id,
-                    session.name,
-                    session.updated_at,
-                    display_path_with_tilde(&session.working_dir)
-                );
-                if !write_line_or_broken_pipe_ok(&mut out, &output)? {
+            let mut groups: BTreeMap<PathBuf, Vec<&Session>> = BTreeMap::new();
+            for session in &sessions {
+                groups
+                    .entry(session.working_dir.clone())
+                    .or_default()
+                    .push(session);
+            }
+
+            let mut group_entries: Vec<(PathBuf, Vec<&Session>)> = groups.into_iter().collect();
+
+            let max_updated = |sessions: &[&Session]| {
+                sessions
+                    .iter()
+                    .map(|s| s.updated_at)
+                    .max()
+                    .unwrap_or_default()
+            };
+
+            if ascending {
+                group_entries.sort_by_key(|(_, s)| max_updated(s));
+            } else {
+                group_entries.sort_by_key(|(_, s)| std::cmp::Reverse(max_updated(s)));
+            }
+
+            for (dir, group_sessions) in &group_entries {
+                let dir_display = display_path_with_tilde(dir);
+                let count = group_sessions.len();
+                if !write_line_or_broken_pipe_ok(
+                    &mut out,
+                    &format!(
+                        "{dir_display} ({count} session{})",
+                        if count == 1 { "" } else { "s" }
+                    ),
+                )? {
                     return Ok(());
                 }
+
+                let display_sessions: Vec<&Session> = if let Some(n) = limit {
+                    group_sessions.iter().take(n).copied().collect()
+                } else {
+                    group_sessions.clone()
+                };
+
+                for session in &display_sessions {
+                    let output = format!(
+                        "  {} - {} - {}",
+                        session.id, session.name, session.updated_at,
+                    );
+                    if !write_line_or_broken_pipe_ok(&mut out, &output)? {
+                        return Ok(());
+                    }
+                }
+
+                if !write_line_or_broken_pipe_ok(&mut out, "")? {
+                    return Ok(());
+                }
+            }
+
+            let total = sessions.len();
+            let dir_count = group_entries.len();
+            if !write_line_or_broken_pipe_ok(
+                &mut out,
+                &format!(
+                    "Total: {total} session{} in {dir_count} director{}",
+                    if total == 1 { "" } else { "s" },
+                    if dir_count == 1 { "y" } else { "ies" }
+                ),
+            )? {
+                return Ok(());
             }
         }
     }


### PR DESCRIPTION
## Summary

Group `leaf session list` output by working directory instead of displaying a flat mixed list.

Closes #45

## Changes

- **Single file**: `crates/leaf-cli/src/commands/session.rs` (+72 / -14 lines)
- Text output now groups sessions under their working directory header
- Each group shows directory path with session count, followed by indented session entries
- Groups sorted by most recent activity (respects `--ascending` flag)
- `--limit` applies per-group for text output, globally for JSON
- `--working_dir` filter works as before (pre-filter, then group)
- JSON output unchanged (backward compatible)

## Before

```
Available sessions:
20260401_5 - enhance: sort session... - 2026-04-01 07:45:07 UTC - ~/src/oss/leaf
20260324_10 - Set up bit.dev studio   - 2026-03-31 09:02:37 UTC - ~/src/oss/aidevos
20260326_1 - TypeScript build fix     - 2026-03-31 08:10:28 UTC - ~/src/oss/air
...all mixed together...
```

## After

```
Available sessions:

~/src/oss/leaf (8 sessions)
  20260401_5 - enhance: sort session... - 2026-04-01 07:59:30 UTC
  20260401_1 - feature: /model highlight - 2026-04-01 07:40:56 UTC
  ...

~/src/oss/aidevos (1 session)
  20260324_10 - Set up bit.dev studio - 2026-03-31 09:02:37 UTC

~/src/oss/air (1 session)
  20260326_1 - TypeScript build fix - 2026-03-31 08:10:28 UTC

Total: 16 sessions in 9 directories
```

## Testing

- [x] `cargo fmt`
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Text output grouped correctly
- [x] JSON output unchanged
- [x] `--ascending` flag works
- [x] `--limit` flag works (per-group)
- [x] `--working_dir` filter works