### PR TITLE
upstream sync: adopt commits 4deebf7550..87ed8c2e5b

### DIFF
--- a/crates/leaf-cli/Cargo.toml
+++ b/crates/leaf-cli/Cargo.toml
@@ -63,6 +63,7 @@ clap_complete = "4.5.62"
 comfy-table = "7.2.2"
 sha2 = "0.10"
 sigstore-verify = { version = "0.6", default-features = false, features = ["rustls"] }
+axum = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["wincred"] }

--- a/crates/leaf-cli/src/cli.rs
+++ b/crates/leaf-cli/src/cli.rs
@@ -738,6 +738,26 @@ enum Command {
         builtins: Vec<String>,
     },
 
+    /// Start ACP server over HTTP and WebSocket
+    #[command(about = "Start ACP server over HTTP and WebSocket")]
+    Serve {
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
+
+        #[arg(long, default_value = "3284")]
+        port: u16,
+
+        #[arg(
+            long = "with-builtin",
+            value_name = "NAME",
+            help = "Add builtin extensions by name (e.g., 'developer' or multiple: 'developer,github')",
+            long_help = "Add one or more builtin extensions that are bundled with leaf by specifying their names, comma-separated",
+            value_delimiter = ',',
+            action = clap::ArgAction::Append
+        )]
+        builtins: Vec<String>,
+    },
+
     /// Start or resume interactive chat sessions
     #[command(
         about = "Start or resume interactive chat sessions",
@@ -975,6 +995,7 @@ fn get_command_name(command: &Option<Command>) -> &'static str {
         Some(Command::Info { .. }) => "info",
         Some(Command::Mcp { .. }) => "mcp",
         Some(Command::Acp { .. }) => "acp",
+        Some(Command::Serve { .. }) => "serve",
         Some(Command::Session { .. }) => "session",
         Some(Command::Project {}) => "project",
         Some(Command::Projects) => "projects",
@@ -999,6 +1020,35 @@ async fn handle_mcp_command(server: McpCommand) -> Result<()> {
         McpCommand::Memory => serve(MemoryServer::new()).await?,
         McpCommand::Tutorial => serve(TutorialServer::new()).await?,
     }
+    Ok(())
+}
+
+async fn handle_serve_command(host: String, port: u16, builtins: Vec<String>) -> Result<()> {
+    use leaf::config::paths::Paths;
+    use leaf_acp::server_factory::{AcpServer, AcpServerFactoryConfig};
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+    use tracing::info;
+
+    let builtins = if builtins.is_empty() {
+        vec!["developer".to_string()]
+    } else {
+        builtins
+    };
+
+    let server = Arc::new(AcpServer::new(AcpServerFactoryConfig {
+        builtins,
+        data_dir: Paths::data_dir(),
+        config_dir: Paths::config_dir(),
+    }));
+    let router = leaf_acp::transport::create_router(server);
+
+    let addr: SocketAddr = format!("{}:{}", host, port).parse()?;
+    info!("Starting ACP server on {}", addr);
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, router).await?;
+
     Ok(())
 }
 
@@ -1510,6 +1560,11 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
         Some(Command::Info { verbose }) => handle_info(verbose),
         Some(Command::Mcp { server }) => handle_mcp_command(server).await,
         Some(Command::Acp { builtins }) => leaf_acp::server::run(builtins).await,
+        Some(Command::Serve {
+            host,
+            port,
+            builtins,
+        }) => handle_serve_command(host, port, builtins).await,
         Some(Command::Session {
             command: Some(cmd), ..
         }) => handle_session_subcommand(cmd).await,

--- a/crates/leaf/src/agents/agent.rs
+++ b/crates/leaf/src/agents/agent.rs
@@ -45,6 +45,7 @@ use crate::providers::errors::ProviderError;
 use crate::recipe::{Author, Recipe, Response, Settings};
 use crate::scheduler_trait::SchedulerTrait;
 use crate::security::adversary_inspector::AdversaryInspector;
+use crate::security::egress_inspector::EgressInspector;
 use crate::security::security_inspector::SecurityInspector;
 use crate::session::extension_data::{EnabledExtensionsState, ExtensionState};
 use crate::session::{Session, SessionManager};
@@ -268,6 +269,7 @@ impl Agent {
 
         // Add security inspector (highest priority - runs first)
         tool_inspection_manager.add_inspector(Box::new(SecurityInspector::new()));
+        tool_inspection_manager.add_inspector(Box::new(EgressInspector::new()));
 
         // Add adversary inspector (LLM-based review, enabled by ~/.config/leaf/adversary.md)
         tool_inspection_manager.add_inspector(Box::new(AdversaryInspector::new(provider.clone())));
@@ -2473,6 +2475,10 @@ mod tests {
         assert!(
             inspector_names.contains(&"adversary"),
             "Tool inspection manager should contain adversary inspector"
+        );
+        assert!(
+            inspector_names.contains(&"egress"),
+            "Tool inspection manager should contain egress inspector"
         );
 
         Ok(())

--- a/crates/leaf/src/agents/platform_extensions/summon.rs
+++ b/crates/leaf/src/agents/platform_extensions/summon.rs
@@ -346,8 +346,11 @@ fn discover_filesystem_sources(working_dir: &Path) -> Vec<Source> {
     let home = dirs::home_dir();
     let config = Paths::config_dir();
 
-    let local_recipe_dirs: Vec<PathBuf> =
-        vec![working_dir.to_path_buf(), working_dir.join(".leaf/recipes")];
+    let local_recipe_dirs: Vec<PathBuf> = vec![
+        working_dir.to_path_buf(),
+        working_dir.join(".leaf/recipes"),
+        working_dir.join(".agents/recipes"),
+    ];
 
     let global_recipe_dirs: Vec<PathBuf> = std::env::var("LEAF_RECIPE_PATH")
         .ok()
@@ -356,7 +359,14 @@ fn discover_filesystem_sources(working_dir: &Path) -> Vec<Source> {
             let sep = if cfg!(windows) { ';' } else { ':' };
             p.split(sep).map(PathBuf::from).collect::<Vec<_>>()
         })
-        .chain([config.join("recipes")])
+        .chain(
+            [
+                Some(config.join("recipes")),
+                home.as_ref().map(|h| h.join(".agents/recipes")),
+            ]
+            .into_iter()
+            .flatten(),
+        )
         .collect();
 
     let local_skill_dirs: Vec<PathBuf> = vec![
@@ -366,6 +376,7 @@ fn discover_filesystem_sources(working_dir: &Path) -> Vec<Source> {
     ];
 
     let global_skill_dirs: Vec<PathBuf> = [
+        home.as_ref().map(|h| h.join(".agents/skills")),
         Some(config.join("skills")),
         home.as_ref().map(|h| h.join(".claude/skills")),
         home.as_ref().map(|h| h.join(".config/agents/skills")),
@@ -377,9 +388,11 @@ fn discover_filesystem_sources(working_dir: &Path) -> Vec<Source> {
     let local_agent_dirs: Vec<PathBuf> = vec![
         working_dir.join(".leaf/agents"),
         working_dir.join(".claude/agents"),
+        working_dir.join(".agents/agents"),
     ];
 
     let global_agent_dirs: Vec<PathBuf> = [
+        home.as_ref().map(|h| h.join(".agents/agents")),
         Some(config.join("agents")),
         home.as_ref().map(|h| h.join(".claude/agents")),
     ]
@@ -1038,6 +1051,8 @@ impl SummonClient {
                 "No sources available for load/delegate.\n\n\
                  Sources are discovered from:\n\
                  • Current recipe's sub_recipes\n\
+                 • .agents/skills/, .agents/recipes/, .agents/agents/ (project-level)\n\
+                 • ~/.agents/skills/, ~/.agents/agents/ (global)\n\
                  • .leaf/recipes/, .leaf/skills/, .leaf/agents/\n\
                  • ~/.config/leaf/recipes/, skills/, agents/\n\
                  • LEAF_RECIPE_PATH directories\n\

--- a/crates/leaf/src/recipe/local_recipes.rs
+++ b/crates/leaf/src/recipe/local_recipes.rs
@@ -28,6 +28,14 @@ fn local_recipe_dirs() -> Vec<PathBuf> {
     local_dirs.push(get_recipe_library_dir(true));
     local_dirs.push(get_recipe_library_dir(false));
 
+    // Also scan .agents/recipes/ for consistency with the .agents/ convention
+    if let Ok(cwd) = env::current_dir() {
+        local_dirs.push(cwd.join(".agents/recipes"));
+    }
+    if let Some(home) = dirs::home_dir() {
+        local_dirs.push(home.join(".agents/recipes"));
+    }
+
     let mut dirs: Vec<PathBuf> = local_dirs
         .into_iter()
         .map(|dir| dir.canonicalize().unwrap_or(dir))

--- a/crates/leaf/src/security/egress_inspector.rs
+++ b/crates/leaf/src/security/egress_inspector.rs
@@ -1,0 +1,411 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use regex::Regex;
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+use crate::config::LeafMode;
+use crate::conversation::message::{Message, ToolRequest};
+use crate::tool_inspection::{InspectionAction, InspectionResult, ToolInspector};
+
+pub struct EgressInspector;
+
+impl EgressInspector {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for EgressInspector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct EgressDestination {
+    kind: String,
+    destination: String,
+    domain: String,
+}
+
+fn extract_destinations(command: &str) -> Vec<EgressDestination> {
+    let mut destinations = Vec::new();
+
+    static URL_RE: OnceLock<Regex> = OnceLock::new();
+    let url_re = URL_RE.get_or_init(|| Regex::new(r#"(?i)(https?|ftp)://[^\s'"<>|;&)]+"#).unwrap());
+    for cap in url_re.find_iter(command) {
+        let url = cap.as_str().to_string();
+        let domain = extract_domain_from_url(&url).unwrap_or_default();
+        if !domain.is_empty() {
+            destinations.push(EgressDestination {
+                kind: "url".to_string(),
+                destination: url,
+                domain,
+            });
+        }
+    }
+
+    static GIT_SSH_RE: OnceLock<Regex> = OnceLock::new();
+    let git_ssh_re = GIT_SSH_RE.get_or_init(|| Regex::new(r#"git@([^:]+):([^\s'"]+)"#).unwrap());
+    for cap in git_ssh_re.captures_iter(command) {
+        let domain = cap[1].to_string();
+        let path = cap[2].to_string();
+        destinations.push(EgressDestination {
+            kind: "git_remote".to_string(),
+            destination: format!("git@{}:{}", domain, path),
+            domain,
+        });
+    }
+
+    static S3_RE: OnceLock<Regex> = OnceLock::new();
+    let s3_re = S3_RE.get_or_init(|| Regex::new(r#"s3://([^/\s'"]+)(/[^\s'"]*)?"#).unwrap());
+    for cap in s3_re.captures_iter(command) {
+        let bucket = cap[1].to_string();
+        let full = cap[0].to_string();
+        destinations.push(EgressDestination {
+            kind: "s3_bucket".to_string(),
+            destination: full,
+            domain: format!("{}.s3.amazonaws.com", bucket),
+        });
+    }
+
+    static GCS_RE: OnceLock<Regex> = OnceLock::new();
+    let gcs_re = GCS_RE.get_or_init(|| Regex::new(r#"gs://([^/\s'"]+)(/[^\s'"]*)?"#).unwrap());
+    for cap in gcs_re.captures_iter(command) {
+        let bucket = cap[1].to_string();
+        let full = cap[0].to_string();
+        destinations.push(EgressDestination {
+            kind: "gcs_bucket".to_string(),
+            destination: full,
+            domain: format!("{}.storage.googleapis.com", bucket),
+        });
+    }
+
+    static SCP_RE: OnceLock<Regex> = OnceLock::new();
+    let scp_re = SCP_RE
+        .get_or_init(|| Regex::new(r"(?:scp|rsync)\s+.*?(?:\S+@)?([a-zA-Z0-9][\w.-]+):").unwrap());
+    for cap in scp_re.captures_iter(command) {
+        let host = cap[1].to_string();
+        destinations.push(EgressDestination {
+            kind: "scp_target".to_string(),
+            destination: cap[0].to_string(),
+            domain: host,
+        });
+    }
+
+    static SSH_RE: OnceLock<Regex> = OnceLock::new();
+    let ssh_re = SSH_RE.get_or_init(|| {
+        Regex::new(r"ssh\s+(?:-\w+\s+\S+\s+)*(?:\S+@)?([a-zA-Z0-9][\w.-]+)").unwrap()
+    });
+    for cap in ssh_re.captures_iter(command) {
+        let host = cap[1].to_string();
+        if !host.starts_with('-') {
+            destinations.push(EgressDestination {
+                kind: "ssh_target".to_string(),
+                destination: cap[0].to_string(),
+                domain: host,
+            });
+        }
+    }
+
+    static DOCKER_RE: OnceLock<Regex> = OnceLock::new();
+    let docker_re = DOCKER_RE.get_or_init(|| {
+        Regex::new(r#"docker\s+(?:push|login)\s+(?:--[^\s]+\s+)*([^\s'"]+)"#).unwrap()
+    });
+    for cap in docker_re.captures_iter(command) {
+        let target = cap[1].to_string();
+        let domain = target.split('/').next().unwrap_or(&target).to_string();
+        destinations.push(EgressDestination {
+            kind: "docker_registry".to_string(),
+            destination: target,
+            domain,
+        });
+    }
+
+    static GENERIC_NET_CMD_RE: OnceLock<Regex> = OnceLock::new();
+    let generic_net_cmd_re = GENERIC_NET_CMD_RE.get_or_init(|| {
+        Regex::new(
+            r"(?i)\b(fetch|nc|ncat|netcat|ftp|sftp|socat|httpie|xh)\b[^\n]*?\b((?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,})\b"
+        ).unwrap()
+    });
+    let already_seen: HashSet<String> = destinations
+        .iter()
+        .map(|d| d.domain.to_lowercase())
+        .collect();
+    for cap in generic_net_cmd_re.captures_iter(command) {
+        let domain = cap[2].to_string();
+        if !already_seen.contains(&domain) {
+            destinations.push(EgressDestination {
+                kind: "generic_network".to_string(),
+                destination: cap[0].to_string(),
+                domain,
+            });
+        }
+    }
+
+    static NPM_PUBLISH_RE: OnceLock<Regex> = OnceLock::new();
+    let npm_publish_re = NPM_PUBLISH_RE
+        .get_or_init(|| Regex::new(r"(?:^|[;&|]\s*|\n)\s*npm\s+publish(?:\s|$)").unwrap());
+    if npm_publish_re.is_match(command) {
+        destinations.push(EgressDestination {
+            kind: "package_publish".to_string(),
+            destination: "npm publish".to_string(),
+            domain: "registry.npmjs.org".to_string(),
+        });
+    }
+
+    static CARGO_PUBLISH_RE: OnceLock<Regex> = OnceLock::new();
+    let cargo_publish_re = CARGO_PUBLISH_RE
+        .get_or_init(|| Regex::new(r"(?:^|[;&|]\s*|\n)\s*cargo\s+publish(?:\s|$)").unwrap());
+    if cargo_publish_re.is_match(command) {
+        destinations.push(EgressDestination {
+            kind: "package_publish".to_string(),
+            destination: "cargo publish".to_string(),
+            domain: "crates.io".to_string(),
+        });
+    }
+
+    destinations
+}
+
+fn extract_domain_from_url(url: &str) -> Option<String> {
+    let after_scheme = url
+        .find("://")
+        .and_then(|i| url.get(i + 3..))
+        .unwrap_or(url);
+    let authority = after_scheme.split('/').next()?;
+    let host_port = authority.split('@').next_back()?;
+    let host = if host_port.contains('[') {
+        host_port
+            .split(']')
+            .next()
+            .map(|s| s.trim_start_matches('['))?
+    } else {
+        host_port.split(':').next()?
+    };
+    if host.is_empty() {
+        None
+    } else {
+        Some(host.to_string())
+    }
+}
+
+fn is_shell_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "shell" | "bash" | "execute_command" | "run_command" | "terminal"
+    ) || name.ends_with("__shell")
+        || name.ends_with("__bash")
+        || name.ends_with("__terminal")
+}
+
+fn is_web_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "web_fetch" | "fetch" | "browser_navigate" | "http_request"
+    ) || name.ends_with("__web_fetch")
+        || name.ends_with("__fetch")
+        || name.ends_with("__browser_navigate")
+}
+
+fn extract_text_for_inspection(
+    tool_call: &rmcp::model::CallToolRequestParams,
+    is_web: bool,
+) -> Option<String> {
+    let args = tool_call.arguments.as_ref()?;
+    let keys: &[&str] = if is_web {
+        &["url", "uri", "endpoint"]
+    } else {
+        &["command", "cmd", "script", "input"]
+    };
+    keys.iter()
+        .find_map(|k| args.get(*k).and_then(|v| v.as_str()).map(|s| s.to_string()))
+}
+
+#[async_trait]
+impl ToolInspector for EgressInspector {
+    fn name(&self) -> &'static str {
+        "egress"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    async fn inspect(
+        &self,
+        _session_id: &str,
+        tool_requests: &[ToolRequest],
+        _messages: &[Message],
+        _goose_mode: LeafMode,
+    ) -> Result<Vec<InspectionResult>> {
+        let mut results = Vec::new();
+        let mut seen_destinations: HashSet<String> = HashSet::new();
+
+        for tool_request in tool_requests {
+            let tool_call = match &tool_request.tool_call {
+                Ok(tc) => tc,
+                Err(_) => continue,
+            };
+
+            let name = tool_call.name.as_ref();
+            let is_web = is_web_tool(name);
+            if !is_shell_tool(name) && !is_web {
+                continue;
+            }
+
+            let text = match extract_text_for_inspection(tool_call, is_web) {
+                Some(t) => t,
+                None => continue,
+            };
+
+            let destinations: Vec<_> = extract_destinations(&text)
+                .into_iter()
+                .filter(|d| seen_destinations.insert(d.destination.clone()))
+                .collect();
+
+            if destinations.is_empty() {
+                continue;
+            }
+
+            for dest in &destinations {
+                tracing::info!(
+                    egress_kind = dest.kind.as_str(),
+                    domain = dest.domain.as_str(),
+                    destination = dest.destination.as_str(),
+                    "egress destination detected"
+                );
+            }
+
+            results.push(InspectionResult {
+                tool_request_id: tool_request.id.clone(),
+                action: InspectionAction::Allow,
+                reason: format!(
+                    "Egress destinations detected: {}",
+                    destinations
+                        .iter()
+                        .map(|d| d.destination.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+                confidence: 0.0,
+                inspector_name: self.name().to_string(),
+                finding_id: None,
+            });
+        }
+
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_destinations() {
+        let dests = extract_destinations("curl https://example.com/api/data");
+        assert_eq!(dests.len(), 1);
+        assert_eq!(dests[0].domain, "example.com");
+
+        let dests = extract_destinations("git remote add origin git@github.com:personal/repo.git");
+        assert_eq!(dests.len(), 1);
+        assert_eq!(dests[0].domain, "github.com");
+
+        let dests = extract_destinations("aws s3 cp data.csv s3://my-bucket/path/data.csv");
+        assert_eq!(dests.len(), 1);
+        assert_eq!(dests[0].kind, "s3_bucket");
+
+        assert_eq!(extract_destinations("ls -la /tmp").len(), 0);
+    }
+
+    #[test]
+    fn test_package_publish_detection() {
+        assert_eq!(extract_destinations("npm publish").len(), 1);
+        assert_eq!(extract_destinations("cd pkg && npm publish").len(), 1);
+        assert_eq!(extract_destinations("cargo publish").len(), 1);
+        assert_eq!(extract_destinations("cargo publish --dry-run").len(), 1);
+
+        assert_eq!(extract_destinations("echo 'npm publish'").len(), 0);
+        assert_eq!(extract_destinations("# npm publish").len(), 0);
+        assert_eq!(extract_destinations("cat npm_publish_guide.md").len(), 0);
+    }
+
+    #[test]
+    fn test_gcs_detection() {
+        let dests = extract_destinations("gsutil cp data.csv gs://my-bucket/path/data.csv");
+        assert_eq!(dests.len(), 1);
+        assert_eq!(dests[0].kind, "gcs_bucket");
+        assert_eq!(dests[0].destination, "gs://my-bucket/path/data.csv");
+        assert_eq!(dests[0].domain, "my-bucket.storage.googleapis.com");
+    }
+
+    #[test]
+    fn test_scp_detection() {
+        let dests = extract_destinations("scp file.txt user@remote.example.com:/tmp/file.txt");
+        assert_eq!(dests.len(), 1);
+        assert_eq!(dests[0].kind, "scp_target");
+        assert_eq!(dests[0].domain, "remote.example.com");
+
+        let dests = extract_destinations("rsync -av ./dist/ deploy@prod.example.com:/var/www/");
+        assert_eq!(dests.len(), 1);
+        assert_eq!(dests[0].kind, "scp_target");
+        assert_eq!(dests[0].domain, "prod.example.com");
+    }
+
+    #[test]
+    fn test_ssh_detection() {
+        let dests = extract_destinations("ssh user@bastion.example.com");
+        assert_eq!(dests.len(), 1);
+        assert_eq!(dests[0].kind, "ssh_target");
+        assert_eq!(dests[0].domain, "bastion.example.com");
+
+        let dests = extract_destinations("ssh -i key.pem ec2-user@10.0.0.1");
+        assert_eq!(dests.len(), 1);
+        assert_eq!(dests[0].kind, "ssh_target");
+        assert_eq!(dests[0].domain, "10.0.0.1");
+    }
+
+    #[test]
+    fn test_docker_detection() {
+        let dests = extract_destinations("docker push registry.example.com/myapp:latest");
+        assert_eq!(dests.len(), 1);
+        assert_eq!(dests[0].kind, "docker_registry");
+        assert_eq!(dests[0].domain, "registry.example.com");
+
+        let dests = extract_destinations("docker login ghcr.io");
+        assert_eq!(dests.len(), 1);
+        assert_eq!(dests[0].kind, "docker_registry");
+        assert_eq!(dests[0].domain, "ghcr.io");
+    }
+
+    #[test]
+    fn test_generic_network_catchall() {
+        let dests = extract_destinations("nc data.exfil.io 9999");
+        assert!(dests
+            .iter()
+            .any(|d| d.kind == "generic_network" && d.domain == "data.exfil.io"));
+
+        let dests = extract_destinations("curl https://example.com/api/data");
+        assert!(!dests.iter().any(|d| d.kind == "generic_network"));
+
+        let dests = extract_destinations("ssh user@bastion.example.com");
+        assert!(!dests.iter().any(|d| d.kind == "generic_network"));
+
+        let dests = extract_destinations("scp file.txt user@remote.example.com:/tmp/");
+        assert!(!dests.iter().any(|d| d.kind == "generic_network"));
+    }
+
+    #[test]
+    fn test_extract_domain_from_url() {
+        assert_eq!(
+            extract_domain_from_url("https://example.com/path"),
+            Some("example.com".to_string())
+        );
+        assert_eq!(
+            extract_domain_from_url("https://user:pass@example.com/path"),
+            Some("example.com".to_string())
+        );
+    }
+}

--- a/crates/leaf/src/security/mod.rs
+++ b/crates/leaf/src/security/mod.rs
@@ -1,5 +1,6 @@
 pub mod adversary_inspector;
 pub mod classification_client;
+pub mod egress_inspector;
 pub mod patterns;
 pub mod scanner;
 pub mod security_inspector;


### PR DESCRIPTION
## Upstream Sync: 4deebf7550..87ed8c2e5b

Adopts CLI-relevant commits from upstream `block/goose` main branch.

Closes #51

### Commits to Apply (3)

| # | Upstream Commit | Description |
|---|----------------|-------------|
| 1 | `dc249f7b62` | feat(security): add egress logging inspector |
| 2 | `277b61c410` | docs: standardize on ~/.agents/skills/ as canonical skill path |
| 3 | `01f879fc1b` | feat: goose serve |

### Commits Skipped (10)

| Upstream Commit | Reason |
|----------------|--------|
| `2cfe21566d` | `ui/text/` only |
| `c4d4ee8e4e` | `ui/text/` only |
| `77d45d2c35` | `ui/text/` only (reverted by next) |
| `1233c308d7` | `ui/text/` only (revert) |
| `0703ffd3fc` | Blog post only |
| `a58ae1b146` | Documentation only |
| `84b4d13287` | Documentation only |
| `496d6d728f` | npm version bumps only |
| `5b3b331a45` | `ui/desktop/` only |
| `87ed8c2e5b` | Dependency bump in `scripts/` |

### Verification Checklist

After each commit:
- [ ] `cargo fmt` passes
- [ ] `cargo check -p leaf -p leaf-cli -p leaf-server` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] Relevant tests pass