### PR TITLE
fix: recover from truncated tool call JSON arguments across all provider formats

### DIFF
--- a/crates/leaf/src/agents/agent.rs
+++ b/crates/leaf/src/agents/agent.rs
@@ -1486,8 +1486,6 @@ impl Agent {
                                                 "A tool call could not be parsed — the response may have been truncated. Try breaking the task into smaller steps or resending your message."
                                             )
                                         );
-                                        exit_chat = true;
-                                        break;
                                     }
                                 }
 

--- a/crates/leaf/src/providers/formats/openai.rs
+++ b/crates/leaf/src/providers/formats/openai.rs
@@ -462,19 +462,42 @@ pub fn response_to_message(response: &Value) -> anyhow::Result<Message> {
                             ));
                         }
                         Err(e) => {
-                            let error = ErrorData {
-                                code: ErrorCode::INVALID_PARAMS,
-                                message: Cow::from(format!(
-                                    "Could not interpret tool use parameters for id {}: {}. Raw arguments: '{}'",
-                                    id, e, arguments_str
-                                )),
-                                data: None,
-                            };
-                            content.push(MessageContent::tool_request_with_metadata(
-                                id,
-                                Err(error),
-                                metadata.as_ref(),
-                            ));
+                            tracing::warn!(
+                                "Streaming: tool {} arguments parsing failed ({} bytes), attempting auto-fix: {}",
+                                function_name,
+                                arguments_str.len(),
+                                e
+                            );
+                            let fix_result = complete_tool_params(&function_name, &arguments_str);
+
+                            match fix_result {
+                                Some(fix) => {
+                                    if let Some(warn_msg) = &fix.warning {
+                                        tracing::warn!("{}", warn_msg);
+                                    }
+                                    content.push(MessageContent::tool_request_with_metadata(
+                                        id,
+                                        Ok(CallToolRequestParams::new(function_name)
+                                            .with_arguments(object(fix.params))),
+                                        metadata.as_ref(),
+                                    ));
+                                }
+                                None => {
+                                    let error = ErrorData {
+                                        code: ErrorCode::INVALID_PARAMS,
+                                        message: Cow::from(format!(
+                                            "Could not interpret tool use parameters for id {}: {}",
+                                            id, e
+                                        )),
+                                        data: None,
+                                    };
+                                    content.push(MessageContent::tool_request_with_metadata(
+                                        id,
+                                        Err(error),
+                                        metadata.as_ref(),
+                                    ));
+                                }
+                            }
                         }
                     }
                 }
@@ -1363,6 +1386,33 @@ mod tests {
                     assert!(msg.starts_with("The provided function name"));
                 }
                 _ => panic!("Expected ToolNotFound error"),
+            }
+        } else {
+            panic!("Expected ToolRequest content");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_to_message_truncated_arguments_auto_fixed() -> anyhow::Result<()> {
+        let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
+        // Simulate a truncated response: the "content" string value is cut off
+        response["choices"][0]["message"]["tool_calls"][0]["function"]["name"] = json!("write");
+        response["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"] =
+            json!("{\"path\": \"test.rs\", \"content\": \"fn main() {");
+
+        let message = response_to_message(&response)?;
+
+        // The auto-fix should complete the truncated JSON and return a valid tool request
+        if let MessageContent::ToolRequest(request) = &message.content[0] {
+            match &request.tool_call {
+                Ok(params) => {
+                    assert_eq!(params.name, "write");
+                    let args = params.arguments.as_ref().unwrap();
+                    assert_eq!(args["path"], json!("test.rs"));
+                }
+                Err(e) => panic!("Expected successful tool request, got error: {:?}", e),
             }
         } else {
             panic!("Expected ToolRequest content");

--- a/crates/leaf/src/providers/formats/openai_responses.rs
+++ b/crates/leaf/src/providers/formats/openai_responses.rs
@@ -2,6 +2,7 @@ use crate::conversation::message::{Message, MessageContent};
 use crate::mcp_utils::extract_text_from_resource;
 use crate::model::ModelConfig;
 use crate::providers::base::{ProviderUsage, Usage};
+use crate::providers::formats::util::parse_tool_arguments;
 use crate::providers::utils::extract_reasoning_effort;
 use anyhow::{anyhow, Error};
 use async_stream::try_stream;
@@ -559,11 +560,7 @@ pub fn responses_api_to_message(response: &ResponsesApiResponse) -> anyhow::Resu
                 ..
             } => {
                 let request_id = call_id.as_ref().unwrap_or(id).clone();
-                let parsed_args = if arguments.is_empty() {
-                    json!({})
-                } else {
-                    serde_json::from_str(arguments).unwrap_or_else(|_| json!({}))
-                };
+                let parsed_args = parse_tool_arguments(name, arguments);
 
                 content.push(MessageContent::tool_request(
                     request_id,
@@ -615,11 +612,7 @@ fn process_streaming_output_items(
                             name,
                             arguments,
                         } => {
-                            let parsed_args = if arguments.is_empty() {
-                                json!({})
-                            } else {
-                                serde_json::from_str(&arguments).unwrap_or_else(|_| json!({}))
-                            };
+                            let parsed_args = parse_tool_arguments(&name, &arguments);
 
                             content.push(MessageContent::tool_request(
                                 id,
@@ -638,11 +631,7 @@ fn process_streaming_output_items(
                 ..
             } => {
                 let request_id = call_id.unwrap_or(id);
-                let parsed_args = if arguments.is_empty() {
-                    json!({})
-                } else {
-                    serde_json::from_str(&arguments).unwrap_or_else(|_| json!({}))
-                };
+                let parsed_args = parse_tool_arguments(&name, &arguments);
 
                 content.push(MessageContent::tool_request(
                     request_id,

--- a/crates/leaf/src/providers/formats/util.rs
+++ b/crates/leaf/src/providers/formats/util.rs
@@ -200,3 +200,37 @@ pub fn complete_json_braces(json_str: &str) -> Option<String> {
 
     None
 }
+
+/// Parses tool arguments from a JSON string, with auto-fix recovery on parse failure.
+/// Returns the parsed JSON value, or falls back to empty `{}` if auto-fix also fails.
+#[inline]
+pub fn parse_tool_arguments(tool_name: &str, arguments: &str) -> Value {
+    if arguments.is_empty() {
+        return json!({});
+    }
+    match serde_json::from_str(arguments) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                "Tool {} arguments parsing failed ({} bytes), attempting auto-fix: {}",
+                tool_name,
+                arguments.len(),
+                e
+            );
+            complete_tool_params(tool_name, arguments)
+                .map(|fix| {
+                    if let Some(w) = &fix.warning {
+                        tracing::warn!("{}", w);
+                    }
+                    fix.params
+                })
+                .unwrap_or_else(|| {
+                    tracing::warn!(
+                        "Failed to auto-fix JSON for tool {}, using empty params",
+                        tool_name
+                    );
+                    json!({})
+                })
+        }
+    }
+}


### PR DESCRIPTION
## Summary

When LLM responses are truncated mid-tool-call, the JSON arguments become incomplete (e.g. missing closing braces, cut-off strings). This PR adds auto-fix recovery across all provider formats so the agent can continue operating instead of failing or silently losing data.

## Problem

Three distinct failure modes when tool call arguments are truncated:

| Provider Format | Previous Behavior | Issue |
|---|---|---|
| `openai.rs` streaming | Returned `INVALID_PARAMS` immediately | Tool call lost entirely |
| `openai_responses.rs` (3 locations) | Silently fell back to `{}` | Arguments discarded silently |
| `agent.rs` | Set `exit_chat = true; break;` | Entire conversation terminated |

## Fix

### 1. Shared helper: `parse_tool_arguments()` in `util.rs`
- New reusable function that attempts `serde_json::from_str` first
- On failure, tries `complete_tool_params()` auto-fix (brace completion + known-schema fill)
- Falls back to `{}` only if auto-fix also fails
- All logging via `tracing::warn` for observability

### 2. Fixed all provider format locations

| File | Location | Fix |
|---|---|---|
| `openai.rs` | Streaming `response_to_message` (~L462) | Added `complete_tool_params` recovery before `INVALID_PARAMS` |
| `openai_responses.rs` | `responses_api_to_message` (~L563) | Replaced silent `{}` fallback with `parse_tool_arguments` |
| `openai_responses.rs` | `ContentPart::ToolCall` (~L615) | Same |
| `openai_responses.rs` | `ResponseOutputItemInfo::FunctionCall` (~L634) | Same |

### 3. Agent no longer exits on parse failure
- Removed `exit_chat = true; break;` from `agent.rs` parse error handler
- Agent continues processing remaining tool calls instead of terminating

### Already safe (no changes needed)
- `openai.rs` non-streaming path — already had `complete_tool_params`
- `anthropic.rs` — arguments already deserialized as `Value`, no string parsing
- `databricks.rs` — already had `complete_tool_params`
- `snowflake.rs` — falls back to `Value::String(...)` preserving raw input

## Testing

- Added `test_response_to_message_truncated_arguments_auto_fixed` test
- All 46 openai/openai_responses format tests pass
- `cargo clippy --all-targets -- -D warnings` clean
- Pre-existing test failures (`test_create_request_enabled_thinking_with_budget`, `test_token_refresh_race_condition`) confirmed on base branch

## Related

- Prerequisite for #55 (file state caching) — this fix ensures truncated responses from long tool calls are handled gracefully