### PR TITLE
fix: handle model command errors gracefully instead of crashing session

### DIFF
--- a/crates/leaf-cli/src/session/mod.rs
+++ b/crates/leaf-cli/src/session/mod.rs
@@ -621,7 +621,9 @@ impl CliSession {
             }
             InputResult::Model(options) => {
                 history.save(editor);
-                self.handle_model_command(options).await?;
+                if let Err(e) = self.handle_model_command(options).await {
+                    output::render_error(&e.to_string());
+                }
             }
             InputResult::Plan(options) => {
                 self.handle_plan_mode(options).await?;


### PR DESCRIPTION
## Summary

Fixes #65 - When a user runs `/model` with an invalid provider (e.g., `/model invalid_provider`), leaf now displays a user-friendly error message and continues the session instead of crashing.

## Root Cause

The `InputResult::Model` case in `handle_input` used the `?` operator which propagates errors up the call stack, causing the session to terminate unexpectedly.

## Fix

Changed from `?` operator to `if let Err` with `output::render_error()` to match the pattern used by other commands (AddExtension, AddBuiltin).

```rust
// Before
self.handle_model_command(options).await?;

// After
if let Err(e) = self.handle_model_command(options).await {
    output::render_error(&e.to_string());
}
```

## Testing

- ✅ `cargo fmt` passes
- ✅ `cargo clippy --all-targets -- -D warnings` passes
- ✅ `cargo test -p leaf-cli` passes (164 tests)

## Checklist

- [x] Code compiles
- [x] Lint passes
- [x] Tests pass
- [x] Commit is signed (DCO)
