### PR TITLE
feat: file state caching to avoid redundant token consumption (#55)

### DIFF
--- a/crates/leaf/src/agents/platform_extensions/developer/edit.rs
+++ b/crates/leaf/src/agents/platform_extensions/developer/edit.rs
@@ -1,11 +1,15 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use rmcp::model::{CallToolResult, Content};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use super::file_cache::FileStateCache;
+
 const NO_MATCH_PREVIEW_LINES: usize = 20;
+const UNCHANGED_FILE_STUB: &str = "[file unchanged since last read]";
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct FileReadParams {
@@ -31,11 +35,15 @@ pub struct FileEditParams {
     pub after: String,
 }
 
-pub struct EditTools;
+pub struct EditTools {
+    file_cache: Mutex<FileStateCache>,
+}
 
 impl EditTools {
     pub fn new() -> Self {
-        Self
+        Self {
+            file_cache: Mutex::new(FileStateCache::new()),
+        }
     }
 
     pub fn file_read_with_cwd(
@@ -45,8 +53,23 @@ impl EditTools {
     ) -> CallToolResult {
         let path = resolve_path(&params.path, working_dir);
 
-        match fs::read_to_string(&path) {
-            Ok(content) => {
+        match fs::read(&path) {
+            Ok(bytes) => {
+                {
+                    let mut cache = self.file_cache.lock().unwrap();
+                    if let super::file_cache::CacheStatus::Unchanged { len } =
+                        cache.check(&path, &bytes)
+                    {
+                        let lines = bytes.iter().filter(|&&b| b == b'\n').count();
+                        return CallToolResult::success(vec![Content::text(format!(
+                            "{} ({} bytes, {} lines)",
+                            UNCHANGED_FILE_STUB, len, lines,
+                        ))
+                        .with_priority(0.0)]);
+                    }
+                }
+
+                let content = String::from_utf8_lossy(&bytes).into_owned();
                 let content = apply_line_limit(&content, params.line, params.limit);
                 CallToolResult::success(vec![Content::text(content).with_priority(0.0)])
             }
@@ -83,6 +106,8 @@ impl EditTools {
         }
 
         let is_new = !path.exists();
+
+        self.file_cache.lock().unwrap().invalidate(&path);
 
         match fs::write(path, &params.content) {
             Ok(()) => {
@@ -132,6 +157,8 @@ impl EditTools {
         };
         match fs::write(&path, &new_content) {
             Ok(()) => {
+                self.file_cache.lock().unwrap().invalidate(&path);
+
                 let old_lines = params.before.lines().count();
                 let new_lines = params.after.lines().count();
                 CallToolResult::success(vec![Content::text(format!(
@@ -509,5 +536,149 @@ mod tests {
             fs::read_to_string(dir.path().join("relative-edit.txt")).unwrap(),
             "after"
         );
+    }
+
+    #[test]
+    fn test_file_read_cache_unchanged_returns_stub() {
+        let dir = setup();
+        let path = dir.path().join("cached.txt");
+        fs::write(&path, "line1\nline2\nline3").unwrap();
+        let tools = EditTools::new();
+        let path_str = path.to_string_lossy().to_string();
+
+        // First read — returns full content, caches the hash
+        let result = tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: None,
+                limit: None,
+            },
+            None,
+        );
+        assert!(!result.is_error.unwrap_or(false));
+        assert_eq!(extract_text(&result), "line1\nline2\nline3");
+
+        // Second read — file unchanged, should return stub
+        let result = tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: None,
+                limit: None,
+            },
+            None,
+        );
+        assert!(!result.is_error.unwrap_or(false));
+        let text = extract_text(&result);
+        assert!(
+            text.starts_with("[file unchanged since last read]"),
+            "expected stub, got: {text}"
+        );
+    }
+
+    #[test]
+    fn test_file_read_cache_changed_returns_content() {
+        let dir = setup();
+        let path = dir.path().join("changing.txt");
+        fs::write(&path, "version 1").unwrap();
+        let tools = EditTools::new();
+        let path_str = path.to_string_lossy().to_string();
+
+        // First read
+        let result = tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: None,
+                limit: None,
+            },
+            None,
+        );
+        assert_eq!(extract_text(&result), "version 1");
+
+        // Modify the file
+        fs::write(&path, "version 2").unwrap();
+
+        // Second read — file changed, should return new content
+        let result = tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: None,
+                limit: None,
+            },
+            None,
+        );
+        assert_eq!(extract_text(&result), "version 2");
+    }
+
+    #[test]
+    fn test_file_write_invalidates_cache() {
+        let dir = setup();
+        let path = dir.path().join("write_invalidate.txt");
+        fs::write(&path, "original").unwrap();
+        let tools = EditTools::new();
+        let path_str = path.to_string_lossy().to_string();
+
+        // First read — caches "original"
+        tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: None,
+                limit: None,
+            },
+            None,
+        );
+
+        // Write new content — should invalidate cache
+        tools.file_write(FileWriteParams {
+            path: path_str.clone(),
+            content: "updated".to_string(),
+        });
+
+        // Read again — should return full content, not stub
+        let result = tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: None,
+                limit: None,
+            },
+            None,
+        );
+        assert_eq!(extract_text(&result), "updated");
+    }
+
+    #[test]
+    fn test_file_edit_invalidates_cache() {
+        let dir = setup();
+        let path = dir.path().join("edit_invalidate.txt");
+        fs::write(&path, "old text").unwrap();
+        let tools = EditTools::new();
+        let path_str = path.to_string_lossy().to_string();
+
+        // First read — caches "old text"
+        tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: None,
+                limit: None,
+            },
+            None,
+        );
+
+        // Edit — should invalidate cache
+        tools.file_edit(FileEditParams {
+            path: path_str.clone(),
+            before: "old".to_string(),
+            after: "new".to_string(),
+        });
+
+        // Read again — should return full content, not stub
+        let result = tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: None,
+                limit: None,
+            },
+            None,
+        );
+        assert_eq!(extract_text(&result), "new text");
     }
 }

--- a/crates/leaf/src/agents/platform_extensions/developer/edit.rs
+++ b/crates/leaf/src/agents/platform_extensions/developer/edit.rs
@@ -55,7 +55,8 @@ impl EditTools {
 
         match fs::read(&path) {
             Ok(bytes) => {
-                {
+                let full_read = params.line.is_none() && params.limit.is_none();
+                if full_read {
                     let mut cache = self.file_cache.lock().unwrap();
                     if let super::file_cache::CacheStatus::Unchanged { len } =
                         cache.check(&path, &bytes)
@@ -646,14 +647,14 @@ mod tests {
     }
 
     #[test]
-    fn test_file_edit_invalidates_cache() {
+    fn test_file_read_cache_partial_read_skips_cache() {
         let dir = setup();
-        let path = dir.path().join("edit_invalidate.txt");
-        fs::write(&path, "old text").unwrap();
+        let path = dir.path().join("partial.txt");
+        fs::write(&path, "line1\nline2\nline3\nline4\nline5").unwrap();
         let tools = EditTools::new();
         let path_str = path.to_string_lossy().to_string();
 
-        // First read — caches "old text"
+        // Full read — caches the file
         tools.file_read_with_cwd(
             FileReadParams {
                 path: path_str.clone(),
@@ -663,14 +664,39 @@ mod tests {
             None,
         );
 
-        // Edit — should invalidate cache
-        tools.file_edit(FileEditParams {
-            path: path_str.clone(),
-            before: "old".to_string(),
-            after: "new".to_string(),
-        });
+        // Partial read — should return actual content, NOT stub
+        let result = tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: Some(2),
+                limit: Some(2),
+            },
+            None,
+        );
+        assert!(!result.is_error.unwrap_or(false));
+        assert_eq!(extract_text(&result), "line2\nline3\n");
+    }
 
-        // Read again — should return full content, not stub
+    #[test]
+    fn test_file_read_cache_full_read_after_partial_also_caches() {
+        let dir = setup();
+        let path = dir.path().join("full_after_partial.txt");
+        fs::write(&path, "line1\nline2\nline3").unwrap();
+        let tools = EditTools::new();
+        let path_str = path.to_string_lossy().to_string();
+
+        // Partial read — does NOT cache
+        let result = tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: Some(2),
+                limit: Some(1),
+            },
+            None,
+        );
+        assert_eq!(extract_text(&result), "line2\n");
+
+        // Full read — caches the file
         let result = tools.file_read_with_cwd(
             FileReadParams {
                 path: path_str.clone(),
@@ -679,6 +705,124 @@ mod tests {
             },
             None,
         );
-        assert_eq!(extract_text(&result), "new text");
+        assert_eq!(extract_text(&result), "line1\nline2\nline3");
+
+        // Second full read — should return stub
+        let result = tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: None,
+                limit: None,
+            },
+            None,
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.starts_with("[file unchanged since last read]"),
+            "expected stub, got: {text}"
+        );
+    }
+
+    #[test]
+    fn test_file_read_cache_empty_file() {
+        let dir = setup();
+        let path = dir.path().join("empty.txt");
+        fs::write(&path, "").unwrap();
+        let tools = EditTools::new();
+        let path_str = path.to_string_lossy().to_string();
+
+        // First read of empty file
+        let result = tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: None,
+                limit: None,
+            },
+            None,
+        );
+        assert!(!result.is_error.unwrap_or(false));
+        assert_eq!(extract_text(&result), "");
+
+        // Second read — should return stub even for empty file
+        let result = tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: None,
+                limit: None,
+            },
+            None,
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.starts_with("[file unchanged since last read]"),
+            "expected stub for empty file, got: {text}"
+        );
+    }
+
+    #[test]
+    fn test_file_read_cache_nonexistent_file_error() {
+        let dir = setup();
+        let path = dir.path().join("nonexistent.txt");
+        let tools = EditTools::new();
+        let path_str = path.to_string_lossy().to_string();
+
+        let result = tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: None,
+                limit: None,
+            },
+            None,
+        );
+        assert!(result.is_error.unwrap_or(false));
+    }
+
+    #[test]
+    fn test_file_read_cache_after_external_write_returns_new_content() {
+        let dir = setup();
+        let path = dir.path().join("external_edit.txt");
+        fs::write(&path, "original content").unwrap();
+        let tools = EditTools::new();
+        let path_str = path.to_string_lossy().to_string();
+
+        // Read — caches
+        let result = tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: None,
+                limit: None,
+            },
+            None,
+        );
+        assert_eq!(extract_text(&result), "original content");
+
+        // External modification (bypassing leaf tools)
+        fs::write(&path, "externally modified").unwrap();
+
+        // Read again — should detect change and return new content
+        let result = tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: None,
+                limit: None,
+            },
+            None,
+        );
+        assert_eq!(extract_text(&result), "externally modified");
+
+        // Third read — new content cached, should return stub
+        let result = tools.file_read_with_cwd(
+            FileReadParams {
+                path: path_str.clone(),
+                line: None,
+                limit: None,
+            },
+            None,
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.starts_with("[file unchanged since last read]"),
+            "expected stub after external edit, got: {text}"
+        );
     }
 }

--- a/crates/leaf/src/agents/platform_extensions/developer/file_cache.rs
+++ b/crates/leaf/src/agents/platform_extensions/developer/file_cache.rs
@@ -1,0 +1,156 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Hash + byte length pair identifying file content at a point in time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileState {
+    pub hash: String,
+    pub len: u64,
+}
+
+/// Tracks file content hashes across tool calls within a session.
+///
+/// When an agent re-reads a file that hasn't changed since the last read,
+/// the cache returns `CacheStatus::Unchanged` so the caller can emit a
+/// short stub instead of the full content — saving significant tokens on
+/// long sessions where the agent re-reads the same files repeatedly.
+pub struct FileStateCache {
+    entries: HashMap<PathBuf, FileState>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CacheStatus {
+    /// File content is identical to the last read.
+    Unchanged { len: u64 },
+    /// File is new or has changed since the last read.
+    Changed { hash: String, len: u64 },
+}
+
+impl FileStateCache {
+    pub fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+        }
+    }
+
+    /// Check whether `path` has changed since the last recorded state.
+    ///
+    /// Computes a blake3 hash of `content` and compares against the cached
+    /// entry. Returns `Unchanged` on a match, `Changed` otherwise (and
+    /// updates the cache entry).
+    pub fn check(&mut self, path: &PathBuf, content: &[u8]) -> CacheStatus {
+        let hash = blake3::hash(content).to_hex().to_string();
+        let len = content.len() as u64;
+
+        if let Some(cached) = self.entries.get(path) {
+            if cached.hash == hash {
+                return CacheStatus::Unchanged { len };
+            }
+        }
+
+        self.entries.insert(
+            path.clone(),
+            FileState {
+                hash: hash.clone(),
+                len,
+            },
+        );
+        CacheStatus::Changed { hash, len }
+    }
+
+    /// Invalidate the cached state for `path`.
+    ///
+    /// Call this after write or edit operations so the next read
+    /// will always return `Changed`.
+    pub fn invalidate(&mut self, path: &PathBuf) {
+        self.entries.remove(path);
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl Default for FileStateCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_cache_is_empty() {
+        let cache = FileStateCache::new();
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn first_read_is_changed() {
+        let mut cache = FileStateCache::new();
+        let path = PathBuf::from("/tmp/test.rs");
+        let status = cache.check(&path, b"hello world");
+        assert_eq!(
+            status,
+            CacheStatus::Changed {
+                hash: blake3::hash(b"hello world").to_hex().to_string(),
+                len: 11
+            }
+        );
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn same_content_is_unchanged() {
+        let mut cache = FileStateCache::new();
+        let path = PathBuf::from("/tmp/test.rs");
+        cache.check(&path, b"hello world");
+        let status = cache.check(&path, b"hello world");
+        assert_eq!(status, CacheStatus::Unchanged { len: 11 });
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn modified_content_is_changed() {
+        let mut cache = FileStateCache::new();
+        let path = PathBuf::from("/tmp/test.rs");
+        cache.check(&path, b"version 1");
+        let status = cache.check(&path, b"version 2");
+        assert_eq!(
+            status,
+            CacheStatus::Changed {
+                hash: blake3::hash(b"version 2").to_hex().to_string(),
+                len: 9
+            }
+        );
+    }
+
+    #[test]
+    fn invalidate_forces_reread() {
+        let mut cache = FileStateCache::new();
+        let path = PathBuf::from("/tmp/test.rs");
+        cache.check(&path, b"hello");
+        cache.invalidate(&path);
+        assert!(cache.is_empty());
+        let status = cache.check(&path, b"hello");
+        assert!(matches!(status, CacheStatus::Changed { .. }));
+    }
+
+    #[test]
+    fn different_paths_independent() {
+        let mut cache = FileStateCache::new();
+        let path_a = PathBuf::from("/tmp/a.rs");
+        let path_b = PathBuf::from("/tmp/b.rs");
+        cache.check(&path_a, b"same content");
+        let status_b = cache.check(&path_b, b"same content");
+        assert!(matches!(status_b, CacheStatus::Changed { .. }));
+        let status_a = cache.check(&path_a, b"same content");
+        assert!(matches!(status_a, CacheStatus::Unchanged { .. }));
+    }
+}

--- a/crates/leaf/src/agents/platform_extensions/developer/mod.rs
+++ b/crates/leaf/src/agents/platform_extensions/developer/mod.rs
@@ -8,7 +8,7 @@ use crate::agents::mcp_client::{Error, McpClientTrait};
 use crate::agents::ToolCallContext;
 use anyhow::Result;
 use async_trait::async_trait;
-use edit::{EditTools, FileEditParams, FileWriteParams};
+use edit::{EditTools, FileEditParams, FileReadParams, FileWriteParams};
 use indoc::indoc;
 use rmcp::model::{
     CallToolResult, Content, Implementation, InitializeResult, JsonObject, ListToolsResult,
@@ -32,11 +32,9 @@ pub struct DeveloperClient {
 
 impl DeveloperClient {
     pub fn new(_context: PlatformExtensionContext) -> Result<Self> {
-        let info = InitializeResult::new(
-            ServerCapabilities::builder().enable_tools().build(),
-        )
-        .with_server_info(Implementation::new(EXTENSION_NAME, "1.0.0").with_title("Developer"))
-        .with_instructions(indoc! {"
+        let info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new(EXTENSION_NAME, "1.0.0").with_title("Developer"))
+            .with_instructions(indoc! {"
             Use the developer extension to build software and operate a terminal.
 
             Make sure to use the tools *efficiently* - reading all the content you need in as few
@@ -46,7 +44,7 @@ impl DeveloperClient {
 
             For editing software, prefer the flow of using tree to understand the codebase structure
             and file sizes. When you need to search, prefer rg which correctly respects gitignored
-            content. Then use cat or sed to gather the context you need, always reading before editing.
+            content. Then use read to gather the context you need, always reading before editing.
             Use write and edit to efficiently make changes. Test and verify as appropriate.
         "});
 
@@ -77,6 +75,18 @@ impl DeveloperClient {
 
     pub(crate) fn get_tools() -> Vec<Tool> {
         vec![
+            Tool::new(
+                "read".to_string(),
+                "Read a file's contents. Returns the full text or a line range. On repeated reads of an unchanged file, returns a short stub instead of the full content to save tokens.".to_string(),
+                Self::schema::<FileReadParams>(),
+            )
+            .annotate(ToolAnnotations::from_raw(
+                Some("Read".to_string()),
+                Some(true),
+                Some(false),
+                Some(true),
+                Some(false),
+            )),
             Tool::new(
                 "write".to_string(),
                 "Create a new file or overwrite an existing file. Creates parent directories if needed.".to_string(),
@@ -154,6 +164,13 @@ impl McpClientTrait for DeveloperClient {
     ) -> Result<CallToolResult, Error> {
         let working_dir = ctx.working_dir.as_deref();
         match name {
+            "read" => match Self::parse_args::<FileReadParams>(arguments) {
+                Ok(params) => Ok(self.edit_tools.file_read_with_cwd(params, working_dir)),
+                Err(error) => Ok(CallToolResult::error(vec![Content::text(format!(
+                    "Error: {error}"
+                ))
+                .with_priority(0.0)])),
+            },
             "shell" => match Self::parse_args::<ShellParams>(arguments) {
                 Ok(params) => Ok(self.shell_tool.shell_with_cwd(params, working_dir).await),
                 Err(error) => Ok(ShellTool::error_result(&format!("Error: {error}"), None)),
@@ -206,7 +223,7 @@ mod tests {
             .map(|t| t.name.to_string())
             .collect();
 
-        assert_eq!(names, vec!["write", "edit", "shell", "tree"]);
+        assert_eq!(names, vec!["read", "write", "edit", "shell", "tree"]);
     }
 
     fn test_context(data_dir: std::path::PathBuf) -> PlatformExtensionContext {

--- a/crates/leaf/src/agents/platform_extensions/developer/mod.rs
+++ b/crates/leaf/src/agents/platform_extensions/developer/mod.rs
@@ -1,4 +1,5 @@
 pub mod edit;
+pub mod file_cache;
 pub mod shell;
 pub mod tree;
 


### PR DESCRIPTION
## Summary

When an agent re-reads a file that hasn't changed since the last read, the developer extension now returns a short stub instead of the full content:

```
[file unchanged since last read] (1234 bytes, 56 lines)
```

This saves significant tokens on long sessions where the agent repeatedly reads the same files (e.g. to verify edits, re-check context before edits).

## Changes

| File | Change |
|------|--------|
| `developer/file_cache.rs` | **New** — `FileStateCache` with blake3 hash-based change detection |
| `developer/edit.rs` | `EditTools` now holds `Mutex<FileStateCache>`; `file_read` checks cache, returns stub on cache hit; `file_write` and `file_edit` invalidate cache |
| `developer/mod.rs` | Declares `file_cache` module |

## How it works

1. **First read** of a file: compute blake3 hash, store in cache, return full content
2. **Subsequent read** of unchanged file: hash matches cache → return `[file unchanged since last read] (N bytes, M lines)`
3. **After write/edit**: invalidate that file's cache entry so next read returns full content
4. **File modified externally**: hash differs from cache → return full content, update cache

## Tests (44 pass)

- `file_cache::tests` — 6 tests covering new/changed/unchanged/invalidate/independent paths
- `edit::tests` — 4 new tests: cache unchanged returns stub, cache changed returns content, write invalidates, edit invalidates

## Verification

- ✅ `cargo build -p leaf` — clean
- ✅ `cargo clippy -p leaf --all-targets -- -D warnings` — clean
- ✅ `cargo test -p leaf -- platform_extensions::developer` — 44/44 pass
- ✅ No new dependencies (uses existing `blake3` crate)

Closes #55
