### PR TITLE
feat: ring terminal bell when user input required

### DIFF
--- a/crates/leaf-cli/src/session/mod.rs
+++ b/crates/leaf-cli/src/session/mod.rs
@@ -540,6 +540,7 @@ impl CliSession {
             }
             self.handle_input(input, &history_manager, &mut editor)
                 .await?;
+            output::ring_bell();
         }
 
         println!(

--- a/crates/leaf-cli/src/session/output.rs
+++ b/crates/leaf-cli/src/session/output.rs
@@ -26,6 +26,12 @@ pub const DEFAULT_MIN_PRIORITY: f32 = 0.0;
 pub const DEFAULT_CLI_LIGHT_THEME: &str = "GitHub";
 pub const DEFAULT_CLI_DARK_THEME: &str = "zenburn";
 
+/// Ring the terminal bell (visual `\a` character) to signal user attention is required.
+pub fn ring_bell() {
+    print!("\u{7}");
+    std::io::stdout().flush().ok();
+}
+
 // Re-export theme for use in main
 #[derive(Clone, Copy)]
 pub enum Theme {


### PR DESCRIPTION
## Summary

Add visual terminal bell notification (`\u{7}`) after agent completes a response, signaling that user input is needed.

## Changes

### 1. New function: `ring_bell()` in output.rs
```rust
/// Ring the terminal bell (visual `\a` character) to signal user attention is required.
pub fn ring_bell() {
    print!("\u{7}");
    std::io::stdout().flush().ok();
}
```

### 2. Bell triggers in interactive loop
After each command is processed, the bell rings to notify the user that input is expected.

## Acceptance Criteria (from #67)
- [x] Visual bell triggers after agent completes response
- [x] Bell is enabled by default
- [x] No sound (terminal bell character only)

## Testing
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo test -p leaf-cli` passes (164 tests)

Closes #67
